### PR TITLE
Reduce variability in line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,32 @@
+# Handle line endings automatically for files detected as text
+# and leave all files detected as binary untouched.
+* text=auto
+
+# Force the default filetypes to have unix eols so all our OSes agree on hashes
+*.* text eol=lf
+
+# These files are binary and should be left untouched
+# (binary is a macro for -text -diff)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.gifv binary
+*.ico binary
+*.mov binary
+*.mp4 binary
+*.mp3 binary
+*.flv binary
+*.fla binary
+*.swf binary
+*.gz binary
+*.zip binary
+*.7z binary
+*.ttf binary
+*.eot binary
+*.woff binary
+*.pyc binary
+*.pdf binary
+*.ez binary
+*.bz2 binary
+*.swp binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -30,3 +30,7 @@
 *.ez binary
 *.bz2 binary
 *.swp binary
+*.rds binary
+*.feather binary
+*.Rds binary
+*.Feather binary

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ rsconnect/
 **.nc
 **.nc.ind
 **_tasks.yml
-*.Rproj
 
 
 

--- a/lake-temperature-model-prep.Rproj
+++ b/lake-temperature-model-prep.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: knitr
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+LineEndingConversion: Posix


### PR DESCRIPTION
One thing we've learned about scipiper is that line endings differences across OSes can cause unnecessary and repeated rebuilds of targets that are, or depend on, text files. I believe the following project configuration changes will help, though we may need to keep an eye out for any problems with existing files.

Everybody with a fork probably already has a local copy of a `lake-temperature-model-prep.Rproj` file. Please allow this one to replace/overwrite your old one.