### PR TITLE
buffered_lakes_sf no longer used downstream

### DIFF
--- a/2_crosswalk_munge.yml
+++ b/2_crosswalk_munge.yml
@@ -25,7 +25,6 @@ targets:
       - 2_crosswalk_munge/out/micorps_nhdhr_xwalk.rds.ind
       - 2_crosswalk_munge/out/mndow_nhdhr_xwalk.rds.ind
       - 2_crosswalk_munge/out/winslow_nhdhr_xwalk.rds.ind
-      - 2_crosswalk_munge/out/buffered_lakes_sf.rds.ind
       - 2_crosswalk_munge/out/centroid_lakes_sf.rds.ind
 
   2_crosswalk_munge/out/gnisname_nhdhr_xwalk.rds.ind:


### PR DESCRIPTION
Removed the `2_crosswalk_munge/out/buffered_lakes_sf.rds.ind` target from the dependency list for `2_crosswalk_munge.yml` because it is no longer being used downstream (https://github.com/USGS-R/lake-temperature-model-prep/commit/6c07e2581c6d30c28a4873ff77355b2dae43baa4#diff-c0b02c23549ba4d285477e0aaa3bd4d8L7). If we didn't remove it as a dependency, it forced an unnecessary rebuild which was very lengthy.