### PR TITLE
Add Cass Lake file and parser

### DIFF
--- a/6_temp_coop_fetch/in/Cass_DO_and_Temp_Profiles.xlsx.ind
+++ b/6_temp_coop_fetch/in/Cass_DO_and_Temp_Profiles.xlsx.ind
@@ -1,0 +1,2 @@
+hash: d107bb906c3a078f3f1442b8a24b93af
+

--- a/7a_temp_coop_munge/src/data_parsers/parse_cass_file.R
+++ b/7a_temp_coop_munge/src/data_parsers/parse_cass_file.R
@@ -1,0 +1,28 @@
+parse_Cass_DO_and_Temp_Profiles <- function(inind, outind) {
+
+  infile <- sc_retrieve(inind, remake_file = '6_temp_coop_fetch_tasks.yml')
+  outfile <- as_data_file(outind)
+
+  dat_raw <- readxl::read_excel(infile)
+
+  # Notes:
+  #   No `time` available in original data
+  #   Has DO column (`DO (mg/L)`), unsure if I should include it
+  #   Not sure about what should go in the `site`` column, so I used the column actually called `Site`
+
+  dat_cleaned <- dat_raw %>%
+    dplyr::mutate(DateTime = as.Date(`Sample Date`),
+                  # Make DOW a character string, and should be 7 long
+                  MN_DOW = sprintf("%07d", MN_DOW)) %>%
+    dplyr::select(DateTime,
+                  depth = `Depth (m)`,
+                  temp = `Temp (C)`,
+                  DOW = MN_DOW,
+                  site = Site) %>%
+    dplyr::arrange(site, DateTime, depth) %>%
+    dplyr::filter(!is.na(depth), !is.na(temp)) %>%
+    dplyr::select(DateTime, temp, depth, DOW, site)
+
+  saveRDS(object = dat_cleaned, file = outfile)
+  sc_indicate(ind_file = outind, data_file = outfile)
+}

--- a/7a_temp_coop_munge/src/parsing_task_fxns.R
+++ b/7a_temp_coop_munge/src/parsing_task_fxns.R
@@ -100,6 +100,7 @@ create_coop_munge_makefile <- function(target_name, taskplan, final_targets) {
                 '7a_temp_coop_munge/src/data_parsers/parse_dakota_files.R',
                 '7a_temp_coop_munge/src/data_parsers/parse_indiana_files.R',
                 '7a_temp_coop_munge/src/data_parsers/parse_tenmile_files.R',
+                '7a_temp_coop_munge/src/data_parsers/parse_cass_file.R',
                 '7a_temp_coop_munge/src/parsing_task_fxns.R',
                 'lib/src/require_local.R',
                 '7a_temp_coop_munge/src/data_parsers/parse_unit_functions.R'),

--- a/build/status/Nl90ZW1wX2Nvb3BfZmV0Y2gvaW4vQ2Fzc19ET19hbmRfVGVtcF9Qcm9maWxlcy54bHN4LmluZA.yml
+++ b/build/status/Nl90ZW1wX2Nvb3BfZmV0Y2gvaW4vQ2Fzc19ET19hbmRfVGVtcF9Qcm9maWxlcy54bHN4LmluZA.yml
@@ -1,0 +1,10 @@
+version: 0.3.0
+name: 6_temp_coop_fetch/in/Cass_DO_and_Temp_Profiles.xlsx.ind
+type: file
+hash: ea989ec2ce9150634344ea31208d54d0
+time: 2020-03-12 14:06:20 UTC
+depends: {}
+fixed: b93055a06d239e690b86ec84f2dfe36f
+code:
+  functions: {}
+


### PR DESCRIPTION
First attempt at using the temp coop stuff - took a few minutes to orient myself, but in the end I was able to build `scmake("7a_temp_coop_munge/tmp/Cass_DO_and_Temp_Profiles.rds", remake_file = "7a_temp_coop_munge_tasks.yml")`. I also did run the following two lines to get the new data indicated:

```r
scmake("6_temp_coop_fetch_tasks.yml", remake_file = "6_temp_coop_fetch.yml")
scmake("6_temp_coop_fetch/in/Cass_DO_and_Temp_Profiles.xlsx.ind", remake_file = "6_temp_coop_fetch_tasks.yml")
```

I was not able to build the `7a_temp_coop_munge.yml` remake file itself. It keeps throwing an error about `coop_wants` being an implicitly created target. I saw that it was from `6_temp_coop_fetch.yml` and was able to add that file to `include` at the top (not committed), which allowed me to build the individual target `7a_temp_coop_munge_tasks.yml`. But when I go to build the `all_coop_dat.rds.ind` target, it yells about duplicate targets.

Doubt this is perfect, but hopefully helps make some forward progress!