### PR TITLE
Targets test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Targets files
+_targets
 # History files
 .Rhistory
 .Rapp.history
@@ -52,6 +54,7 @@ rsconnect/
 *.xml
 *.xlsx
 *.Rdata
+*.png
 # "in" cooperator data
 /6_temp_coop_fetch/in/*
 !/6_temp_coop_fetch/in/*.ind

--- a/7_drivers_munge.yml
+++ b/7_drivers_munge.yml
@@ -4,10 +4,13 @@ packages:
   - scipiper
   - dplyr
   - stringr
+  - targets
 
 sources:
   - 6_drivers/src/nldas_feather_utils.R
   - 7_drivers_munge/src/GLM_driver_utils.R
+  - 7_drivers_munge/src/GCM_targets_wrapper.R
+  - 7_drivers_munge/src/GCM_driver_utils.R
 
 targets:
   7_drivers_munge:
@@ -46,3 +49,8 @@ targets:
   7_drivers_munge/out/7_all_local_drivers.rds.ind:
     command: index_local_drivers(target_name,
       depends = "7_drivers_munge/out/7_drivers_munge_tasks.ind")
+
+  7_drivers_munge/out/7_GCM_driver_files.ind:
+    command: build_GCM_pipeline(
+      target_name,
+      "2_crosswalk_munge/out/centroid_lakes_sf.rds.ind")

--- a/7_drivers_munge/out/7_GCM_driver_files.ind
+++ b/7_drivers_munge/out/7_GCM_driver_files.ind
@@ -1,0 +1,2 @@
+hash: 9f3d5ffa593039e58cd805d59b0f018e
+

--- a/7_drivers_munge/out/7_GCM_driver_files.ind
+++ b/7_drivers_munge/out/7_GCM_driver_files.ind
@@ -1,2 +1,3 @@
-hash: 9f3d5ffa593039e58cd805d59b0f018e
+2_crosswalk_munge/out/centroid_lakes_sf.rds: 7dfbdba8229eeeac0516e1cd264928a3
+7_drivers_munge/out/centroid_map.png: 9f3d5ffa593039e58cd805d59b0f018e
 

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -1,0 +1,12 @@
+library(sf)
+library(ggplot2)
+
+map_centroids <- function(centroids_sf, out_file) {
+
+  centroid_plot <- ggplot() +
+    geom_sf(data=centroids_sf, color='dodgerblue', size=0.5)
+
+  ggsave(out_file, centroid_plot, width=10, height=8, dpi=300)
+
+  return(out_file)
+}

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -1,5 +1,3 @@
-library(sf)
-library(ggplot2)
 
 map_centroids <- function(centroids_sf_rds, out_file) {
   centroids_sf <- readRDS(centroids_sf_rds)

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -1,8 +1,8 @@
 library(sf)
 library(ggplot2)
 
-map_centroids <- function(centroids_sf, out_file) {
-
+map_centroids <- function(centroids_sf_rds, out_file) {
+  centroids_sf <- readRDS(centroids_sf_rds)
   centroid_plot <- ggplot() +
     geom_sf(data=centroids_sf, color='dodgerblue', size=0.5)
 

--- a/7_drivers_munge/src/GCM_targets_wrapper.R
+++ b/7_drivers_munge/src/GCM_targets_wrapper.R
@@ -1,6 +1,6 @@
 build_GCM_pipeline <- function(ind_file, ...) {
   # Build the targets pipeline
-  tar_make()
+  tar_make(pipeline_files_out)
 
   # Load the final target that lists the output files
   tar_load(pipeline_files_out)

--- a/7_drivers_munge/src/GCM_targets_wrapper.R
+++ b/7_drivers_munge/src/GCM_targets_wrapper.R
@@ -1,0 +1,7 @@
+build_GCM_pipeline <- function(ind_file, ...) {
+
+  tar_make()
+
+  tar_load(centroid_map_png)
+  sc_indicate(ind_file, data_file=c(centroid_map_png))
+}

--- a/7_drivers_munge/src/GCM_targets_wrapper.R
+++ b/7_drivers_munge/src/GCM_targets_wrapper.R
@@ -1,7 +1,10 @@
 build_GCM_pipeline <- function(ind_file, ...) {
-
+  # Build the targets pipeline
   tar_make()
 
+  # Load the final target that lists the output files
   tar_load(pipeline_files_out)
+
+  # Indicate those file names and hashes
   sc_indicate(ind_file, data_file=pipeline_files_out)
 }

--- a/7_drivers_munge/src/GCM_targets_wrapper.R
+++ b/7_drivers_munge/src/GCM_targets_wrapper.R
@@ -2,6 +2,6 @@ build_GCM_pipeline <- function(ind_file, ...) {
 
   tar_make()
 
-  tar_load(centroid_map_png)
-  sc_indicate(ind_file, data_file=c(centroid_map_png))
+  tar_load(pipeline_files_out)
+  sc_indicate(ind_file, data_file=pipeline_files_out)
 }

--- a/_targets.R
+++ b/_targets.R
@@ -1,0 +1,22 @@
+library(targets)
+
+options(tidyverse.quiet = TRUE)
+tar_option_set(packages = c("tidyverse", "sf", "scipiper"))
+
+
+source('7_drivers_munge/src/GCM_driver_utils.R')
+
+targets_list <- list(
+  tar_target(
+    centroids_sf,
+    gd_get(ind_file = '2_crosswalk_munge/out/centroid_lakes_sf.rds.ind') %>% readRDS
+  ),
+  tar_target(
+    centroid_map_png,
+    map_centroids(centroids_sf, out_file = '7_drivers_munge/out/centroid_map.png'),
+    format='file'
+  )
+)
+
+# Return the complete list of targets
+c(targets_list)

--- a/_targets.R
+++ b/_targets.R
@@ -1,7 +1,7 @@
 library(targets)
 
 options(tidyverse.quiet = TRUE)
-tar_option_set(packages = c("tidyverse", "sf", "scipiper"))
+tar_option_set(packages = c("tidyverse", "sf", "scipiper", "ggplot2"))
 
 
 source('7_drivers_munge/src/GCM_driver_utils.R')

--- a/_targets.R
+++ b/_targets.R
@@ -8,13 +8,18 @@ source('7_drivers_munge/src/GCM_driver_utils.R')
 
 targets_list <- list(
   tar_target(
-    centroids_sf,
-    gd_get(ind_file = '2_crosswalk_munge/out/centroid_lakes_sf.rds.ind') %>% readRDS
+    centroids_sf_rds,
+    gd_get('2_crosswalk_munge/out/centroid_lakes_sf.rds.ind'),
+    format='file'
   ),
   tar_target(
     centroid_map_png,
-    map_centroids(centroids_sf, out_file = '7_drivers_munge/out/centroid_map.png'),
+    map_centroids(centroids_sf_rds, out_file = '7_drivers_munge/out/centroid_map.png'),
     format='file'
+  ),
+  tar_target(
+    pipeline_files_out,
+    c(centroids_sf_rds, centroid_map_png)
   )
 )
 

--- a/build/status/N19kcml2ZXJzX211bmdlL291dC83X0dDTV9kcml2ZXJfZmlsZXMuaW5k.yml
+++ b/build/status/N19kcml2ZXJzX211bmdlL291dC83X0dDTV9kcml2ZXJfZmlsZXMuaW5k.yml
@@ -2,11 +2,11 @@ version: 0.3.0
 name: 7_drivers_munge/out/7_GCM_driver_files.ind
 type: file
 hash: ff16b70a357f12e2e17f30ae44375844
-time: 2021-11-10 17:00:32 UTC
+time: 2021-11-12 15:26:34 UTC
 depends:
   2_crosswalk_munge/out/centroid_lakes_sf.rds.ind: 3863d7a358596a912c2d87fca11e2d37
 fixed: ecd2ace6bd2c040576a545a1d62e37ad
 code:
   functions:
-    build_GCM_pipeline: 1e426f89923999bf03c39afdc3b1b7cd
+    build_GCM_pipeline: 63276e5fe8dbcdadaf1f253d64bc92d8
 

--- a/build/status/N19kcml2ZXJzX211bmdlL291dC83X0dDTV9kcml2ZXJfZmlsZXMuaW5k.yml
+++ b/build/status/N19kcml2ZXJzX211bmdlL291dC83X0dDTV9kcml2ZXJfZmlsZXMuaW5k.yml
@@ -1,0 +1,12 @@
+version: 0.3.0
+name: 7_drivers_munge/out/7_GCM_driver_files.ind
+type: file
+hash: cb02e318645ec836130d8a31d65cce3f
+time: 2021-11-10 16:35:13 UTC
+depends:
+  2_crosswalk_munge/out/centroid_lakes_sf.rds.ind: 3863d7a358596a912c2d87fca11e2d37
+fixed: ecd2ace6bd2c040576a545a1d62e37ad
+code:
+  functions:
+    build_GCM_pipeline: cdc897a9236f3fca11c297b78b7037b7
+

--- a/build/status/N19kcml2ZXJzX211bmdlL291dC83X0dDTV9kcml2ZXJfZmlsZXMuaW5k.yml
+++ b/build/status/N19kcml2ZXJzX211bmdlL291dC83X0dDTV9kcml2ZXJfZmlsZXMuaW5k.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
 name: 7_drivers_munge/out/7_GCM_driver_files.ind
 type: file
-hash: cb02e318645ec836130d8a31d65cce3f
-time: 2021-11-10 16:35:13 UTC
+hash: ff16b70a357f12e2e17f30ae44375844
+time: 2021-11-10 17:00:32 UTC
 depends:
   2_crosswalk_munge/out/centroid_lakes_sf.rds.ind: 3863d7a358596a912c2d87fca11e2d37
 fixed: ecd2ace6bd2c040576a545a1d62e37ad
 code:
   functions:
-    build_GCM_pipeline: cdc897a9236f3fca11c297b78b7037b7
+    build_GCM_pipeline: 1e426f89923999bf03c39afdc3b1b7cd
 


### PR DESCRIPTION
Set up a simple working example of a targets pipeline within a scipiper pipeline, where the names and hashes of the files generated by the targets pipeline are stored in an indicator file.