### PR TITLE
Basic geoknife query added to the GCM pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,4 +80,6 @@ build/status/N2FfdGVtcF9jb29wX211bmdlL3RtcC9*
 # ignore source metdata csv
 7b_temp_merge/in/source_metadata.csv
 7b_temp_merge/out/source_metadata_for_release.csv
-
+# Ignore GCM pipeline intermediate files
+7_drivers_munge/tmp/*
+!7_drivers_munge/tmp/.empty

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -1,10 +1,16 @@
 
-map_centroids <- function(centroids_sf_rds, out_file) {
-  centroids_sf <- readRDS(centroids_sf_rds)
-  centroid_plot <- ggplot() +
-    geom_sf(data=centroids_sf, color='dodgerblue', size=0.5)
+map_query <- function(out_file, centroids_sf, polys_sf) {
 
-  ggsave(out_file, centroid_plot, width=10, height=8, dpi=300)
+  # TODO: delete this WI-specific view
+  wi_sf <- st_as_sf(maps::map('state', 'wisconsin', plot=FALSE, fill=TRUE))
+
+  query_plot <- ggplot() +
+    geom_sf(data=wi_sf) +
+    geom_sf(data=polys_sf, color='dodgerblue', fill=NA, size=1) +
+    geom_sf(data=centroids_sf, color='salmon', size=4) +
+    coord_sf() + theme_void()
+
+  ggsave(out_file, query_plot, width=10, height=8, dpi=300)
 
   return(out_file)
 }

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -8,3 +8,51 @@ map_centroids <- function(centroids_sf_rds, out_file) {
 
   return(out_file)
 }
+
+# TODO: a much better solution. For now, this just subsets the lakes
+# to 5 in WI, but it will need to do smart chunking at some point.
+split_lake_centroids <- function(centroids_sf_rds) {
+
+  set.seed(19) # Same subset of 5 every time
+  wi_sf <- st_as_sf(maps::map('state', 'wisconsin', plot=FALSE, fill=TRUE))
+
+  readRDS(centroids_sf_rds) %>%
+    st_intersection(wi_sf) %>%
+    sample_n(5)
+}
+
+# Take the lake centroids and convert into a polygon to query
+# the Geo Data Portal for driver data.
+centroids_to_poly <- function(centroids_sf) {
+  centroids_sf %>%
+    st_make_grid()
+}
+
+# Convert an sf object into a geoknife::simplegeom, so that
+# it can be used in the geoknife query. Must become an
+# `sp` object first.
+sf_to_simplegeom <- function(sf_obj) {
+  sf_obj %>%
+    as_Spatial() %>%
+    simplegeom()
+}
+
+# Set up a download file to get the raw GCM data down.
+# This function accepts each of the query parameters for the
+# geoknife job as an argument. Currently missing the "knife" parameter.
+download_gcm_data <- function(out_file, query_geom, query_url, query_vars,
+                              query_dates, query_knife = NULL) {
+  gcm_job <- geoknife(
+    stencil = query_geom,
+    fabric = webdata(
+      url = query_url,
+      variables = query_vars,
+      times = query_dates
+    )
+  )
+
+  wait(gcm_job)
+  download(gcm_job, destination = out_file, overwrite = TRUE)
+
+  return(out_file)
+}

--- a/7_drivers_munge/src/GCM_targets_wrapper.R
+++ b/7_drivers_munge/src/GCM_targets_wrapper.R
@@ -1,10 +1,10 @@
 build_GCM_pipeline <- function(ind_file, ...) {
   # Build the targets pipeline
-  tar_make(pipeline_files_out)
+  tar_make(gcm_files_out)
 
   # Load the final target that lists the output files
-  tar_load(pipeline_files_out)
+  tar_load(gcm_files_out)
 
   # Indicate those file names and hashes
-  sc_indicate(ind_file, data_file=pipeline_files_out)
+  sc_indicate(ind_file, data_file=gcm_files_out)
 }

--- a/_targets.R
+++ b/_targets.R
@@ -52,13 +52,17 @@ targets_list <- list(
   ),
 
   tar_target(
-    centroid_map_png,
-    map_centroids(centroids_sf_rds, out_file = '7_drivers_munge/out/centroid_map.png'),
+    query_map_png,
+    map_query(
+      out_file = '7_drivers_munge/out/query_map.png',
+      centroids_sf = query_centroids_sf,
+      polys_sf = query_polys_sf
+    ),
     format='file'
   ),
   tar_target(
     gcm_files_out,
-    c(gcm_data_raw_txt, centroid_map_png)
+    c(gcm_data_raw_txt, query_map_png)
   )
 )
 

--- a/_targets.R
+++ b/_targets.R
@@ -48,7 +48,8 @@ targets_list <- list(
       query_url = "https://cida.usgs.gov/thredds/dodsC/notaro_GFDL_1980_1999",
       query_vars = c("evspsbl", "hfss", "mrso"),
       query_dates = c('1999-01-01', '1999-01-15')
-    )
+    ),
+    format = "file"
   ),
 
   tar_target(

--- a/_targets.R
+++ b/_targets.R
@@ -18,7 +18,7 @@ targets_list <- list(
     format='file'
   ),
   tar_target(
-    pipeline_files_out,
+    gcm_files_out,
     c(centroids_sf_rds, centroid_map_png)
   )
 )

--- a/_targets.R
+++ b/_targets.R
@@ -1,17 +1,56 @@
 library(targets)
 
 options(tidyverse.quiet = TRUE)
-tar_option_set(packages = c("tidyverse", "sf", "scipiper", "ggplot2"))
-
+tar_option_set(packages = c(
+  "tidyverse",
+  "sf",
+  "scipiper",
+  "ggplot2",
+  "geoknife"
+))
 
 source('7_drivers_munge/src/GCM_driver_utils.R')
 
 targets_list <- list(
+  # The input from our `scipiper` pipeline
   tar_target(
     centroids_sf_rds,
     gd_get('2_crosswalk_munge/out/centroid_lakes_sf.rds.ind'),
     format='file'
   ),
+
+  tar_target(
+    query_centroids_sf,
+    split_lake_centroids(centroids_sf_rds)
+  ),
+
+  # Convert the lake centroids to some kind of polygon for querying GDP
+  tar_target(
+    query_polys_sf,
+    centroids_to_poly(query_centroids_sf)
+  ),
+
+  # Convert the sf polygons into a geoknife-ready format
+  tar_target(
+    query_polys_geoknife,
+    sf_to_simplegeom(query_polys_sf)
+  ),
+
+  # TODO: make this parameterized/branched. Right now, just doing
+  # a single GCM, but will want to parameterize to each of them +
+  # handle chunks of lakes. See this config file example for an example:
+  # https://github.com/USGS-R/necsc-lake-modeling/blob/a81a0e7ed6ede66253f765b42568a4d39a5dccc2/configs/ACCESS_config.yml
+  tar_target(
+    gcm_data_raw_txt,
+    download_gcm_data(
+      out_file = "7_drivers_munge/tmp/7_GCM_GFDL_raw.txt",
+      query_geom = query_polys_geoknife,
+      query_url = "https://cida.usgs.gov/thredds/dodsC/notaro_GFDL_1980_1999",
+      query_vars = c("evspsbl", "hfss", "mrso"),
+      query_dates = c('1999-01-01', '1999-01-15')
+    )
+  ),
+
   tar_target(
     centroid_map_png,
     map_centroids(centroids_sf_rds, out_file = '7_drivers_munge/out/centroid_map.png'),
@@ -19,7 +58,7 @@ targets_list <- list(
   ),
   tar_target(
     gcm_files_out,
-    c(centroids_sf_rds, centroid_map_png)
+    c(gcm_data_raw_txt, centroid_map_png)
   )
 )
 


### PR DESCRIPTION
Part of #222 

This adds a few targets to take a subset of `centroid_lakes_sf`, convert to query-able polygons, and download GFDL GCM data as a raw text file. Then, it maps the subset of centroids and the polygons used for the query.

I think merging this basic framework will allow us to work in parallel on 1) the best way to make polygons from our centroids, and 2) munging the text files into a useful format. Later, we will need to work on chunking the centroids in a smarter way and how to do more than one of the GCMs at a time.

Here is the image created:

![query_map](https://user-images.githubusercontent.com/13220910/141517066-a4ac1e31-848b-40b3-b8ae-7d516bd51aef.png)
