### PR TITLE
Use centroids for GCM query

### DIFF
--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -27,19 +27,14 @@ split_lake_centroids <- function(centroids_sf_rds) {
     sample_n(5)
 }
 
-# Take the lake centroids and convert into a polygon to query
-# the Geo Data Portal for driver data.
-centroids_to_poly <- function(centroids_sf) {
-  centroids_sf %>%
-    st_make_grid()
-}
-
 # Convert an sf object into a geoknife::simplegeom, so that
-# it can be used in the geoknife query. Must become an
-# `sp` object first.
-sf_to_simplegeom <- function(sf_obj) {
+# it can be used in the geoknife query. `geoknife` only works
+# with `sp` objects but not SpatialPoints at the moment, so
+# need to convert these to a data.frame.
+sf_pts_to_simplegeom <- function(sf_obj) {
   sf_obj %>%
-    as_Spatial() %>%
+    st_coordinates() %>%
+    t() %>% as.data.frame() %>%
     simplegeom()
 }
 

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -53,7 +53,8 @@ download_gcm_data <- function(out_file, query_geom, query_url, query_vars,
   )
 
   wait(gcm_job)
-  download(gcm_job, destination = out_file, overwrite = TRUE)
+  my_data <- result(gcm_job)
+  arrow::write_feather(my_data, out_file)
 
   return(out_file)
 }

--- a/_targets.R
+++ b/_targets.R
@@ -6,7 +6,8 @@ tar_option_set(packages = c(
   "sf",
   "scipiper",
   "ggplot2",
-  "geoknife"
+  "geoknife",
+  "arrow"
 ))
 
 source('7_drivers_munge/src/GCM_driver_utils.R')
@@ -35,12 +36,13 @@ targets_list <- list(
   # handle chunks of lakes. See this config file example for an example:
   # https://github.com/USGS-R/necsc-lake-modeling/blob/a81a0e7ed6ede66253f765b42568a4d39a5dccc2/configs/ACCESS_config.yml
   tar_target(
-    gcm_data_raw_txt,
+    gcm_data_raw_feather,
     download_gcm_data(
-      out_file = "7_drivers_munge/tmp/7_GCM_GFDL_raw.txt",
+      out_file = "7_drivers_munge/tmp/7_GCM_GFDL_raw.feather",
       query_geom = query_centroids_geoknife,
       query_url = "https://cida.usgs.gov/thredds/dodsC/notaro_GFDL_1980_1999",
-      query_vars = c("evspsbl", "hfss", "mrso"),
+      # Data definitions: https://cida.usgs.gov/thredds/ncss/notaro_GFDL_2040_2059/dataset.html
+      query_vars = c("evspsbl"), # TODO: more than one var, but geoknife isn't working with that
       query_dates = c('1999-01-01', '1999-01-15')
     ),
     format = "file"

--- a/_targets.R
+++ b/_targets.R
@@ -24,16 +24,10 @@ targets_list <- list(
     split_lake_centroids(centroids_sf_rds)
   ),
 
-  # Convert the lake centroids to some kind of polygon for querying GDP
-  tar_target(
-    query_polys_sf,
-    centroids_to_poly(query_centroids_sf)
-  ),
-
   # Convert the sf polygons into a geoknife-ready format
   tar_target(
-    query_polys_geoknife,
-    sf_to_simplegeom(query_polys_sf)
+    query_centroids_geoknife,
+    sf_pts_to_simplegeom(query_centroids_sf)
   ),
 
   # TODO: make this parameterized/branched. Right now, just doing
@@ -44,7 +38,7 @@ targets_list <- list(
     gcm_data_raw_txt,
     download_gcm_data(
       out_file = "7_drivers_munge/tmp/7_GCM_GFDL_raw.txt",
-      query_geom = query_polys_geoknife,
+      query_geom = query_centroids_geoknife,
       query_url = "https://cida.usgs.gov/thredds/dodsC/notaro_GFDL_1980_1999",
       query_vars = c("evspsbl", "hfss", "mrso"),
       query_dates = c('1999-01-01', '1999-01-15')


### PR DESCRIPTION
Change GCM query to work with centroids + use nice geoknife helper, `result()` instead of `download()` to avoid a bunch of parsing work. Currently only working with one variable, but have in issue [here](https://github.com/USGS-R/geoknife/issues/399) to help resolve that. 