### PR TITLE
Munge GCM downloads into GLM-ready variables

### DIFF
--- a/7_drivers_munge/src/GCM_driver_nc_utils.R
+++ b/7_drivers_munge/src/GCM_driver_nc_utils.R
@@ -13,149 +13,15 @@
 generate_gcm_nc <- function(nc_file, gcm_raw_files, dim_time_input, dim_cell_input,
                             vars_info, global_att, overwrite = TRUE) {
 
-  # Setup the NetCDF file with appropriate dimensions and attributes
-  build_gcm_nc_skeleton(nc_file, dim_time_input, dim_cell_input, vars_info, global_att, overwrite = overwrite)
+  # Use `ncdfgeom` to write out the NetCDF DSG file
+  # See example at https://github.com/jread-usgs/lakesurf-data-release/blob/main/src/ncdf_utils.R#L66-L76
+  # And more discussion in https://github.com/USGS-R/lake-temperature-model-prep/issues/252
+  # ncdfgeom::write_timeseries_dsg(nc_file)
 
-  # Populate the NetCDF file with data from each of the tiles.
-  # Opens and then closes the `nc_file` each loop iteration.
-  for(tile_fn in gcm_raw_files) {
-    arrow::read_feather(tile_fn) %>%
-      push_gcm_nc_data(nc_file, var_names = vars_info$var_name)
-  }
+  # TODO: remove this step which just creates an empty file
+  # with a .nc extension as a placeholder
+  writeLines("PLACEHOLDER", nc_file)
 
   return(nc_file)
 }
-
-
-#' @title Creates a blank NetCDF file for storing GCM driver data
-#' @description Creates a NetCDF file with appropriate dimensions and NA values
-#' to be filled in with real values where available in `push_gcm_nc_data()`. This
-#' function was adapted from functions shared by J. Zwart on 12/03/2021. See more at
-#' https://code.usgs.gov/wma/wp/forecast-pgdl-da/-/blob/main/2_forecast_prep/src/nc_utils.R
-#' @param nc_file netcdf file name output
-#' @param dim_time_input vector of GCM driver data dates
-#' @param dim_cell_input vector of all GCM driver grid cells (whether or not data was pulled)
-#' @param vars_info variables and descriptions to store in NetCDF
-#' @param global_att global attribute description for the data in this NetCDF file (e.g. notaro_ACCESS_1980_1999)
-#' @param overwrite T/F if the nc file should be overwritten if it exists already
-build_gcm_nc_skeleton <- function(nc_file, dim_time_input, dim_cell_input, vars_info, global_att, overwrite = TRUE) {
-
-  ##### Set dimensions; should always be [time, cell] #####
-
-  # Setup time dimension
-  times <- as.integer(seq(0, length(dim_time_input) - 1, 1)) # days since dim_time_input[1]
-  time_dim <- ncdim_def("time",
-                        units = sprintf('days since %s', dim_time_input[1]),
-                        longname = 'time',
-                        vals = times)
-
-  # Setup grid cell dimension
-  cells_dim <- ncdim_def("gridcells",
-                         units = "",
-                         longname = 'GCM grid cell number from lake-temperature-model-prep',
-                         vals = dim_cell_input)
-
-  # Check that units are valid
-  udunits2::ud.is.parseable(time_dim$units)
-  udunits2::ud.is.parseable(cells_dim$units)
-
-  ##### Define variables #####
-
-  fillvalue <- NA # fill for missing data
-
-  def_list <- list()
-
-  n_vars <- nrow(vars_info)
-  # loop through observation variables and define name, units, precision
-  for(i in 1:n_vars){
-    cur_var <- vars_info$var_name[i]
-
-    def_list[[i]] <- ncvar_def(name =  vars_info$var_name[i],
-                               units = vars_info$units[i],
-                               dim = list(time_dim, cells_dim),
-                               missval = fillvalue,
-                               longname = vars_info$longname[i],
-                               prec = vars_info$precision[i])
-  }
-
-  ##### Write out the file #####
-
-  if(file.exists(nc_file)){
-    if(overwrite){
-      file.remove(nc_file)
-      ncout <- nc_create(nc_file, def_list, force_v4 = T)
-    }else{stop('cannot overwrite nc output file')}
-  }else{ncout <- nc_create(nc_file, def_list, force_v4 = T)}
-
-
-  ##### Add global file metadata #####
-  ncatt_put(nc = ncout,
-            varid = 0,
-            attname = "file_description",
-            attval = global_att,
-            prec =  "text")
-
-  nc_close(ncout)
-  return(nc_file)
-
-}
-
-#' @title insert GCM data into an existing NetCDF file
-#' @description Using the NetCDF file created from `build_gcm_nc_skeleton()`, this
-#' function will populate the file with the actual data.
-#' @param gcm_df data frame with the GCM data to insert. Assumes this data has a
-#' date column, a column called `variable` containing values that can be matched to
-#' `var_names`, and a column for each of the grid cell's data named by the cell number.
-#' This argument is first so that the function can be piped to pass in the data.frame.
-#' @param nc_file file path to the netcdf file
-#' @param var_names vector of variable names to loop through
-push_gcm_nc_data <- function(gcm_df, nc_file, var_names){
-
-  # Open the NetCDF file
-  ncout <- nc_open(nc_file, write = T)
-
-  # Cycle through each of the variables (outer `for` loop) & then the grid cells
-  # containing data (inner `for` loop). For each, extract a vector of containing
-  # data for the current cell and variable and then insert into the appropriate
-  # dimensions within the NetCDF file.
-  for(cur_var in var_names){
-
-    # Extract the current variable's info from the nc data
-    cur_var_att <- ncout$var[[cur_var]]
-    varsize <- cur_var_att$varsize
-    n_dims <- cur_var_att$ndims
-
-    # Order of the GCM dimensions as created in `build_gcm_nc_skeleton()`; [time_dim, cells_dim]
-    dim_time_pos <- 1
-    dim_cells_pos <- 2
-
-    # Extract GCM values for the current variable from the bigger GCM data frame
-    cur_var_df <- dplyr::filter(gcm_df, variable == cur_var)
-
-    # Cycle through only cells that are in the `gcm_df`rather than all 9000+ grid cells for each variable
-    # and each file. To find the cells that have data, force column names to be numeric and then only keep
-    # ones that succeed (so this assumes that the only numeric column names are the grid cell columns, which
-    # seems reasonable). As of 12/7, non-cell colnames are "date", "variable", "statistic", and "units"
-    available_cells <- na.omit(as.numeric(names(gcm_df)))
-
-    for(cur_cell in available_cells){
-
-      # Define where to start & how many values to add for each dimension [time_dim, cells_dim]
-      start <- c(1, cur_cell)
-      count <- c(varsize[dim_time_pos], 1) # Use all of the slots for the time dimension, but only one for the cell dimension
-
-      # Extract GCM values for the current cell from the corresponding column in the GCM data frame
-      cur_cell_vals <- cur_var_df[[as.character(cur_cell)]]
-
-      ncvar_put(nc = ncout,
-                varid = cur_var,
-                vals = cur_cell_vals,
-                start = start,
-                count = count)
-    }
-  }
-
-  nc_close(ncout)
-}
-
 

--- a/7_drivers_munge/src/GCM_driver_nc_utils.R
+++ b/7_drivers_munge/src/GCM_driver_nc_utils.R
@@ -1,0 +1,168 @@
+# Munging driver data from geoknife to create NetCDF for each GCM.
+
+# # Example of extracting one cell's timeseries data
+# x <- nc_open("7_drivers_munge/out/7_GCM_ACCESS.nc")
+# cell_i <- 4650
+# xx <- ncvar_get(x, "evspsbl", start = c(1,cell_i), count = c(-1,1))
+
+#' @title Creates a NetCDF file with GCM driver data
+#' @description For each of the GCMs, create a single NetCDF file containing all the
+#' variables and all the grid cells.
+#' @param nc_file netcdf file name output
+#' @param gcm_raw_files vector of feather file paths, one for each tile with data for the current GCM.
+#' @param dim_time_input vector of GCM driver data dates
+#' @param dim_cell_input vector of all GCM driver grid cells (whether or not data was pulled)
+#' @param vars_info variables and descriptions to store in NetCDF
+#' @param global_att global attribute description for the observations (e.g. notaro_ACCESS_1980_1999)
+#' @param overwrite T/F if the nc file should be overwritten if it exists already
+generate_gcm_nc <- function(nc_file, gcm_raw_files, dim_time_input, dim_cell_input,
+                            vars_info, global_att, overwrite = TRUE) {
+
+  # Setup the NetCDF file with appropriate dimensions and attributes
+  build_gcm_nc_skeleton(nc_file, dim_time_input, dim_cell_input, vars_info, global_att, overwrite = overwrite)
+
+  # Populate the NetCDF file with data from each of the tiles.
+  # Opens and then closes the `nc_file` each loop iteration.
+  for(tile_fn in gcm_raw_files) {
+    arrow::read_feather(tile_fn) %>%
+      push_gcm_nc_data(nc_file, var_names = vars_info$var_name)
+  }
+
+  return(nc_file)
+}
+
+
+#' @title Creates a blank NetCDF file for storing GCM driver data
+#' @description Creates a NetCDF file with appropriate dimensions and NA values
+#' to be filled in with real values where available in `push_gcm_nc_data()`. This
+#' function was adapted from functions shared by J. Zwart on 12/03/2021. See more at
+#' https://code.usgs.gov/wma/wp/forecast-pgdl-da/-/blob/main/2_forecast_prep/src/nc_utils.R
+#' @param nc_file netcdf file name output
+#' @param dim_time_input vector of GCM driver data dates
+#' @param dim_cell_input vector of all GCM driver grid cells (whether or not data was pulled)
+#' @param vars_info variables and descriptions to store in NetCDF
+#' @param global_att global attribute description for the data in this NetCDF file (e.g. notaro_ACCESS_1980_1999)
+#' @param overwrite T/F if the nc file should be overwritten if it exists already
+build_gcm_nc_skeleton <- function(nc_file, dim_time_input, dim_cell_input, vars_info, global_att, overwrite = TRUE) {
+
+  ##### Set dimensions; should always be [time, cell] #####
+
+  # Setup time dimension
+  # TODO: currently hourly timesteps but I believe these should be
+  # adjusted to days by changing the geoknife query
+  times <- as.integer(seq(0, length(dim_time_input) - 1, 1)) # hours since dim_time_input[1]
+  time_dim <- ncdim_def("time",
+                        units = sprintf('hours since %s', dim_time_input[1]),
+                        longname = 'time',
+                        vals = times)
+
+  # Setup grid cell dimension
+  cells_dim <- ncdim_def("gridcells",
+                         units = "",
+                         longname = 'GCM grid cell number from lake-temperature-model-prep',
+                         vals = dim_cell_input)
+
+  # Check that units are valid
+  udunits2::ud.is.parseable(time_dim$units)
+  udunits2::ud.is.parseable(cells_dim$units)
+
+  ##### Define variables #####
+
+  fillvalue <- NA # fill for missing data
+
+  def_list <- list()
+
+  n_vars <- nrow(vars_info)
+  # loop through observation variables and define name, units, precision
+  for(i in 1:n_vars){
+    cur_var <- vars_info$var_name[i]
+
+    def_list[[i]] <- ncvar_def(name =  vars_info$var_name[i],
+                               units = vars_info$units[i],
+                               dim = list(time_dim, cells_dim),
+                               missval = fillvalue,
+                               longname = vars_info$longname[i],
+                               prec = vars_info$precision[i])
+  }
+
+  ##### Write out the file #####
+
+  if(file.exists(nc_file)){
+    if(overwrite){
+      file.remove(nc_file)
+      ncout <- nc_create(nc_file, def_list, force_v4 = T)
+    }else{stop('cannot overwrite nc output file')}
+  }else{ncout <- nc_create(nc_file, def_list, force_v4 = T)}
+
+
+  ##### Add global file metadata #####
+  ncatt_put(nc = ncout,
+            varid = 0,
+            attname = "file_description",
+            attval = global_att,
+            prec =  "text")
+
+  nc_close(ncout)
+  return(nc_file)
+
+}
+
+#' @title insert GCM data into an existing NetCDF file
+#' @description Using the NetCDF file created from `build_gcm_nc_skeleton()`, this
+#' function will populate the file with the actual data.
+#' @param gcm_df data frame with the GCM data to insert. Assumes this data has a
+#' date column, a column called `variable` containing values that can be matched to
+#' `var_names`, and a column for each of the grid cell's data named by the cell number.
+#' This argument is first so that the function can be piped to pass in the data.frame.
+#' @param nc_file file path to the netcdf file
+#' @param var_names vector of variable names to loop through
+push_gcm_nc_data <- function(gcm_df, nc_file, var_names){
+
+  # Open the NetCDF file
+  ncout <- nc_open(nc_file, write = T)
+
+  # Cycle through each of the variables (outer `for` loop) & then the grid cells
+  # containing data (inner `for` loop). For each, extract a vector of containing
+  # data for the current cell and variable and then insert into the appropriate
+  # dimensions within the NetCDF file.
+  for(cur_var in var_names){
+
+    # Extract the current variable's info from the nc data
+    cur_var_att <- ncout$var[[cur_var]]
+    varsize <- cur_var_att$varsize
+    n_dims <- cur_var_att$ndims
+
+    # Order of the GCM dimensions as created in `build_gcm_nc_skeleton()`; [time_dim, cells_dim]
+    dim_time_pos <- 1
+    dim_cells_pos <- 2
+
+    # Extract GCM values for the current variable from the bigger GCM data frame
+    cur_var_df <- dplyr::filter(gcm_df, variable == cur_var)
+
+    # Cycle through only cells that are in the `gcm_df`rather than all 9000+ grid cells for each variable
+    # and each file. To find the cells that have data, force column names to be numeric and then only keep
+    # ones that succeed (so this assumes that the only numeric column names are the grid cell columns, which
+    # seems reasonable). As of 12/7, non-cell colnames are "DateTime", "variable", "statistic", and "units"
+    available_cells <- na.omit(as.numeric(names(gcm_df)))
+
+    for(cur_cell in available_cells){
+
+      # Define where to start & how many values to add for each dimension [time_dim, cells_dim]
+      start <- c(1, cur_cell)
+      count <- c(varsize[dim_time_pos], 1) # Use all of the slots for the time dimension, but only one for the cell dimension
+
+      # Extract GCM values for the current cell from the corresponding column in the GCM data frame
+      cur_cell_vals <- cur_var_df[[as.character(cur_cell)]]
+
+      ncvar_put(nc = ncout,
+                varid = cur_var,
+                vals = cur_cell_vals,
+                start = start,
+                count = count)
+    }
+  }
+
+  nc_close(ncout)
+}
+
+

--- a/7_drivers_munge/src/GCM_driver_nc_utils.R
+++ b/7_drivers_munge/src/GCM_driver_nc_utils.R
@@ -1,10 +1,5 @@
 # Munging driver data from geoknife to create NetCDF for each GCM.
 
-# # Example of extracting one cell's timeseries data
-# x <- nc_open("7_drivers_munge/out/7_GCM_ACCESS.nc")
-# cell_i <- 4650
-# xx <- ncvar_get(x, "evspsbl", start = c(1,cell_i), count = c(-1,1))
-
 #' @title Creates a NetCDF file with GCM driver data
 #' @description For each of the GCMs, create a single NetCDF file containing all the
 #' variables and all the grid cells.
@@ -48,11 +43,9 @@ build_gcm_nc_skeleton <- function(nc_file, dim_time_input, dim_cell_input, vars_
   ##### Set dimensions; should always be [time, cell] #####
 
   # Setup time dimension
-  # TODO: currently hourly timesteps but I believe these should be
-  # adjusted to days by changing the geoknife query
-  times <- as.integer(seq(0, length(dim_time_input) - 1, 1)) # hours since dim_time_input[1]
+  times <- as.integer(seq(0, length(dim_time_input) - 1, 1)) # days since dim_time_input[1]
   time_dim <- ncdim_def("time",
-                        units = sprintf('hours since %s', dim_time_input[1]),
+                        units = sprintf('days since %s', dim_time_input[1]),
                         longname = 'time',
                         vals = times)
 
@@ -142,7 +135,7 @@ push_gcm_nc_data <- function(gcm_df, nc_file, var_names){
     # Cycle through only cells that are in the `gcm_df`rather than all 9000+ grid cells for each variable
     # and each file. To find the cells that have data, force column names to be numeric and then only keep
     # ones that succeed (so this assumes that the only numeric column names are the grid cell columns, which
-    # seems reasonable). As of 12/7, non-cell colnames are "DateTime", "variable", "statistic", and "units"
+    # seems reasonable). As of 12/7, non-cell colnames are "date", "variable", "statistic", and "units"
     available_cells <- na.omit(as.numeric(names(gcm_df)))
 
     for(cur_cell in available_cells){

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -285,7 +285,7 @@ convert_to_daily <- function(in_file, time_colname = "DateTime") {
     # these in the final data by including in the `group_by()` call.
     dplyr::group_by(date, variable, statistic, units) %>%
     # TODO: should we `na.rm = TRUE`?
-    dplyr::summarize(across(.fns = ~ mean(.x, na.rm = FALSE))) %>%
+    dplyr::summarize(across(.fns = ~ mean(.x, na.rm = FALSE)), .groups = "keep") %>%
     # Move the variable, statistic, and units column back after the data columns
     dplyr::relocate(all_of(c("variable", "statistic", "units")), .after = last_col())
 

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -282,6 +282,22 @@ download_gcm_data <- function(out_file_template, query_geom,
   return(out_file)
 }
 
+#' @title Pull out individual file information from a dynamically mapped target
+#' @description Use a dynamically mapped target to extract information about
+#' the individual branch files to build a table that can group files and then
+#' trigger rebuilds when individual files within a group change.
+#' @param dynamic_branch_names character vector of the names of each branch created
+#' from running `names()` using the target dynamically branched target as input.
+#' @return a tibble with three columns (`name` = target name of the branch, `path`
+#' = character string of the file created by that branch, and `data` = hash code
+#' indicating the current state of the file) and a row for each branch.
+build_branch_file_hash_table <- function(dynamic_branch_names) {
+  # Get metadata for all the branches of the dynamic target
+  tar_meta(all_of(dynamic_branch_names), c("path", "data")) %>%
+    # There is just one path per branch, so remove the `list` format from this column
+    unnest(path)
+}
+
 #' @title Summarize hourly output from geoknife to daily
 #' @description the final GCM driver data will need to be daily, but geoknife
 #' returns hourly values. This step summarizes the data into daily values. It

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -304,6 +304,20 @@ build_branch_file_hash_table <- function(dynamic_branch_names) {
 #' values and converts into appropriate units. It creates a file with the exact
 #' same name, except that the "_raw" part of the `in_file` filepath is replaced
 #' with "_daily".
+#' @value a table saved as a feather file with the following columns:
+#' `time`: class Date denoting a single day
+#' `cell`: a numeric value indicating which cell in the grid that the data belongs to
+#' `Shortwave`: a numeric value copied from the Notaro `rsns` variable
+#' `Longwave`: FILL INFO IN HERE
+#' `AirTemp`: a numeric value converted from Kelvin to Celcius using the Notaro `tas` variable
+#' `RelHum`: FILL INFO IN HERE
+#' `WindSpeed`: a numeric value representing the product of the Southerly and Westerly
+#' velocities (Notaro variables `uas` and `vas`, respectively)
+#' `Rain`: a numeric value; the rate of rainfall in meters per day. Derived from the Notaro
+#' precipitation flux (`pr`), assuming density of water is 1000 kg/m3.
+#' `Snow`: a numeric value; the rate of snowfall in meters per day. Derived from the `Rain`
+#' column and assumes the snow depth is 10 times the water equivalent (`Rain`) when the
+#' temperature (`AirTemp`) is below freezing.
 #' @param in_file filepath to a feather file containing the hourly geoknife data
 munge_notaro_to_glm <- function(in_file) {
 

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -298,13 +298,14 @@ build_branch_file_hash_table <- function(dynamic_branch_names) {
     unnest(path)
 }
 
-#' @title Summarize hourly output from geoknife to daily
-#' @description the final GCM driver data will need to be daily, but geoknife
-#' returns hourly values. This step summarizes the data into daily values. It
-#' creates a file with the exact same name, except that the "_raw" part of the
-#' `in_file` filepath is replaced with "_daily".
+#' @title Convert Notaro GCM data to GLM-ready data
+#' @description The final GCM driver data will need to be daily, but geoknife
+#' returns hourly values. This step summarizes the Notaro raw data into daily
+#' values and converts into appropriate units. It creates a file with the exact
+#' same name, except that the "_raw" part of the `in_file` filepath is replaced
+#' with "_daily".
 #' @param in_file filepath to a feather file containing the hourly geoknife data
-munge_to_glm <- function(in_file) {
+munge_notaro_to_glm <- function(in_file) {
 
   daily_data <- arrow::read_feather(in_file) %>%
 

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -319,8 +319,17 @@ munge_notaro_to_glm <- function(in_file) {
     pivot_wider(id_cols = c("DateTime", "cell"), names_from = variable, values_from = val) %>%
 
     # Unit conversions to get GLM-ready variables from GDP ones
-    mutate(AirTemp = tas - 273.15, # Convert GDP air temperature (tas) from Kelvin to Celcius
-           Rain = pr # TODO: Convert GDP precipitation (pr) from kg/m2/s to meters/hour
+    mutate(
+      # Convert GDP air temperature (tas) from Kelvin to Celcius
+      AirTemp = tas - 273.15,
+
+      # Convert GDP precipitation (pr) from  kg m-2 s-1 to m/day
+      #  1. Eqn for pr: pr (kg m-2 s-1) = density of water (kg m-3) * rate of rainfall (m/s)
+      #  2. Solve for rate of rainfall:
+      #       rate of rainfall (m/day) = pr (kg m-2 s-1) / density of water (kg m-3) * 3600 sec/hr * 24 hr/day
+      #  3. Assume density of water is 1000 kg/m3
+      Rain = pr / 1000 * 3600 * 24
+
     ) %>%
 
     # Simply rename GDP variables into GLM variables

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -317,9 +317,6 @@ munge_to_glm <- function(in_file) {
     # Also, removes `units` and `statistic` columns which are specific to each variable
     pivot_wider(id_cols = c("DateTime", "cell"), names_from = variable, values_from = val) %>%
 
-    # TODO: remove this. Just temporarily working with one timestep
-    # filter(DateTime < as.POSIXct("1999-01-02 00:00:00", tz = "UTC")) %>%
-
     # Unit conversions to get GLM-ready variables from GDP ones
     mutate(AirTemp = tas - 273.15, # Convert GDP air temperature (tas) from Kelvin to Celcius
            Rain = pr # TODO: Convert GDP precipitation (pr) from kg/m2/s to meters/hour

--- a/_targets.R
+++ b/_targets.R
@@ -149,6 +149,20 @@ targets_list <- list(
   ##### Munge GDP output into NetCDF files that will feed into GLM #####
 
   # Need to munge GCM variables into useable GLM variables
+  tar_target(glm_vars_info,
+             tibble(
+               # TODO: MISSING LONGWAVE
+               var_name = c("Rain", "AirTemp", "Snow", "RelHum", "Shortwave", "Longwave", "WindSpeed"),
+               longname = c("Total daily rainfall",
+                            "Total daily snowfall derived from precipitation and air temp",
+                            "Average daily near surface air temperature",
+                            "Average daily percent relative humidity",
+                            "Average daily surface downward shortwave flux in air",
+                            "LONGWAVE EXPLANATION",
+                            "Average daily windspeed derived from anemometric zonal and anenometric meridional wind components"),
+               units = c("meters", "meters", "degrees Celcius", "", "???", "???", "???"),
+               precision = "float"
+             )),
   tar_target(
     gcm_data_daily_feather,
     munge_to_glm(gcm_data_raw_feather),

--- a/_targets.R
+++ b/_targets.R
@@ -12,6 +12,7 @@ tar_option_set(packages = c(
 ))
 
 source('7_drivers_munge/src/GCM_driver_utils.R')
+source('7_drivers_munge/src/GCM_driver_nc_utils.R')
 
 targets_list <- list(
 
@@ -111,8 +112,16 @@ targets_list <- list(
   # BUILD QUERY
   # Define list of GCMs
   tar_target(gcm_names, c('ACCESS', 'GFDL')),#, 'CNRM', 'IPSL', 'MRI', 'MIROC')),
-  tar_target(gcm_vars, c("evspsbl", "hfss")),
   tar_target(gcm_dates, c('1999-01-01', '1999-01-15')),
+  tar_target(gcm_vars_info,
+             # Gathered manually from https://cida.usgs.gov/thredds/ncss/notaro_GFDL_2040_2059/dataset.html
+             tibble(
+               var_name = c("evspsbl", "hfss"),
+               longname = c("Total evapotranspiration flux", "Sensible heat flux"),
+               units = c("(kg * m^2)/s", "W / m^2"),
+               precision = "float"
+             )),
+  tar_target(gcm_vars, gcm_vars_info$var_name),
 
   # Download data from GDP for each tile & GCM name combination.
   # If the cells in a tile don't change, then the tile should not need to rebuild.
@@ -132,7 +141,37 @@ targets_list <- list(
   ),
 
   ##### Munge GDP output into NetCDF files that will feed into GLM #####
-  # TODO - munge data
+
+  # TODO: create snow from rain, see https://github.com/USGS-R/lake-temperature-model-prep/issues/222
+
+  # Group resulting feather files by GCM to map over
+  tar_target(gcm_data_raw_feather_group_by_gcm,
+             tibble(gcm_file = gcm_data_raw_feather) %>%
+               mutate(gcm_name = gsub("7_drivers_munge/tmp/7_GCM_|_tile([0-9]+)_raw.feather", "", gcm_file)) %>%
+               group_by(gcm_name) %>%
+               tar_group(),
+             iteration = "group"),
+
+  # TODO: currently returning hours ... should be days
+  tar_target(gcm_times_returned, arrow::read_feather(gcm_data_raw_feather[1]) %>% pull(DateTime) %>% unique()),
+
+  # Create single NetCDF files for each of the GCMs
+  tar_target(
+    gcm_nc, {
+      gcm_name <- unique(gcm_data_raw_feather_group_by_gcm$gcm_name)
+      generate_gcm_nc(
+        nc_file = sprintf("7_drivers_munge/out/7_GCM_%s.nc", gcm_name),
+        gcm_raw_files = gcm_data_raw_feather_group_by_gcm$gcm_file,
+        # TODO: replace with sequence (or not?!) once daily, not hourly are being returned
+        dim_time_input = gcm_times_returned,
+        # dim_time_input = seq(gcm_dates[1], gcm_dates[2], by = 1),
+        dim_cell_input = grid_cells_sf$cell_no,
+        vars_info = gcm_vars_info,
+        global_att = sprintf("GCM Notaro %s", gcm_name)
+      )
+    },
+    pattern = map(gcm_data_raw_feather_group_by_gcm)
+  ),
 
 
   ##### Get list of final output files to link back to scipiper pipeline #####

--- a/_targets.R
+++ b/_targets.R
@@ -226,7 +226,7 @@ targets_list <- list(
         gcm_raw_files = gcm_data_daily_feather_group_by_gcm$gcm_file,
         dim_time_input = gcm_dates_all,
         dim_cell_input = grid_cells_sf$cell_no,
-        vars_info = gcm_vars_info,
+        vars_info = glm_vars_info,
         global_att = sprintf("GCM Notaro %s", gcm_name)
       )
     },

--- a/_targets.R
+++ b/_targets.R
@@ -121,8 +121,8 @@ targets_list <- list(
              tibble(
                projection_period = c('1980_1999', '2040_2059', '2080_2099'),
                start_datetime = c('1980-01-01 00:00:00', '2040-01-01 00:00:00', '2080-01-01 00:00:00'),
-               # TODO: scale up to the full time period
-               end_datetime = c('1980-01-15 23:00:00', '2040-01-15 00:00:00', '2080-01-15 00:00:00')
+               # Include midnight on the final day of the time period
+               end_datetime = c('2000-01-01 00:00:00', '2060-01-01 00:00:00', '2100-01-01 00:00:00')
              )),
   # Gathered manually from https://cida.usgs.gov/thredds/ncss/notaro_GFDL_2040_2059/dataset.html
   tar_target(gcm_query_vars, c("pr", "tas", "qas", "rsns", "uas", "vas")), # missing longwave radiation

--- a/_targets.R
+++ b/_targets.R
@@ -8,7 +8,8 @@ tar_option_set(packages = c(
   "scipiper",
   "ggplot2",
   "geoknife",
-  "arrow"
+  "arrow",
+  "retry"
 ))
 
 source('7_drivers_munge/src/GCM_driver_utils.R')
@@ -116,7 +117,7 @@ targets_list <- list(
 
   # BUILD QUERY
   # Define list of GCMs
-  tar_target(gcm_names, c('ACCESS', 'GFDL')),#, 'CNRM', 'IPSL', 'MRI', 'MIROC')),
+  tar_target(gcm_names, c('ACCESS', 'GFDL', 'CNRM', 'IPSL', 'MRI', 'MIROC')),
   tar_target(gcm_dates_df,
              tibble(
                projection_period = c('1980_1999', '2040_2059', '2080_2099'),

--- a/_targets.R
+++ b/_targets.R
@@ -148,15 +148,13 @@ targets_list <- list(
 
   ##### Munge GDP output into NetCDF files that will feed into GLM #####
 
-  # First, need to summarize the hourly data into daily output
+  # Need to munge GCM variables into useable GLM variables
   tar_target(
     gcm_data_daily_feather,
-    convert_to_daily(gcm_data_raw_feather),
+    munge_to_glm(gcm_data_raw_feather),
     pattern = map(gcm_data_raw_feather),
     format = "file"
   ),
-
-  # TODO: create snow from rain, see https://github.com/USGS-R/lake-temperature-model-prep/issues/222
 
   # Group daily feather files by GCM to map over
   tar_target(gcm_data_daily_feather_group_by_gcm,

--- a/_targets.R
+++ b/_targets.R
@@ -142,7 +142,8 @@ targets_list <- list(
     # TODO: might need to split across variables, too. Once we scale up, our queries
     # might be too large and chunking by variable could help.
     pattern = cross(query_cells_centroids_list_by_tile, gcm_names, gcm_dates_df),
-    format = "file"
+    format = "file",
+    error = "continue"
   ),
 
   ##### Munge GDP output into NetCDF files that will feed into GLM #####

--- a/_targets.R
+++ b/_targets.R
@@ -159,7 +159,7 @@ targets_list <- list(
   # Group daily feather files by GCM to map over
   tar_target(gcm_data_daily_feather_group_by_gcm,
              tibble(gcm_file = gcm_data_daily_feather) %>%
-               mutate(gcm_name = gsub("7_drivers_munge/tmp/7_GCM_|_([0-9]{4}){4}_([0-9]{4})_tile([0-9]+)_daily.feather", "", gcm_file)) %>%
+               mutate(gcm_name = str_extract(gcm_file, paste(gcm_names, collapse="|"))) %>%
                group_by(gcm_name) %>%
                tar_group(),
              iteration = "group"),

--- a/_targets.R
+++ b/_targets.R
@@ -174,6 +174,7 @@ targets_list <- list(
   # Create feather files that can be used in the GLM pipeline without
   # having to be munged and extracted via NetCDF. Temporary solution
   # while we work out some NetCDF challenges.
+  # TODO: delete once we finish the NetCDF DSG build (see issue #252)
   tar_target(
     out_skipnc_feather, {
       out_dir <- "7_drivers_munge/out_skipnc"
@@ -218,7 +219,7 @@ targets_list <- list(
   # Create single NetCDF files for each of the GCMs
   tar_target(
     gcm_nc, {
-      # Grouped by GCM name so this should just return one value
+      # Grouped by GCM name so this should just return one unique value
       gcm_name <- unique(gcm_data_daily_feather_group_by_gcm$gcm_name)
 
       generate_gcm_nc(

--- a/_targets.R
+++ b/_targets.R
@@ -129,7 +129,6 @@ targets_list <- list(
 
   # Download data from GDP for each tile & GCM name combination.
   # If the cells in a tile don't change, then the tile should not need to rebuild.
-  # TODO: map over other time periods- 1980-1999 + 2040-2059 + 2080-2099
   tar_target(
     gcm_data_raw_feather,
     download_gcm_data(

--- a/_targets.R
+++ b/_targets.R
@@ -197,9 +197,11 @@ targets_list <- list(
     format = "file"
   ),
 
-  # Group daily feather files by GCM to map over
+  # Group daily feather files by GCM to map over and include
+  # branch file hashes to trigger rebuilds for groups as needed
   tar_target(gcm_data_daily_feather_group_by_gcm,
-             tibble(gcm_file = gcm_data_daily_feather) %>%
+              build_branch_file_hash_table(names(gcm_data_daily_feather)) %>%
+               rename(gcm_file = path) %>%
                mutate(gcm_name = str_extract(gcm_file, paste(gcm_names, collapse="|"))) %>%
                group_by(gcm_name) %>%
                tar_group(),


### PR DESCRIPTION
In addition to the munging, this adds

- a temporary way to get all the GCM data as feather files to skip NetCDF files & my original attempt at making a NetCDF file (see #252) and unblock Hayley (those files were zipped up and manually uploaded [here in Sharepoint](https://doimspp.sharepoint.com/:u:/r/sites/IIDDStaff/Shared%20Documents/Project%20-%20Modeling%20Lakes/GLM/lake-temperature-process-models/ProcessModel_1PrepTmp_files_20211221.zip?csf=1&web=1&e=ggNuqx) for now)
- expands the time ranges to use the full time period (fixes #264)

Putting this up here now but just want it to sit for now. Need to do the following before it can be reviewed:
- [x] Delete NetCDF attempt (or actually solve by doing #252)
- [x] add `retry()` to GCM download code
- [ ] ~add some basic optimization to the pivoting code~ (waiting to do this later given mixed results. See https://github.com/USGS-R/lake-temperature-model-prep/issues/258#issuecomment-1006063738)