### PR TITLE
Increase tile size from 10x10 to 15x15

### DIFF
--- a/_targets.R
+++ b/_targets.R
@@ -38,7 +38,7 @@ targets_list <- list(
   # at a time. Since marching through timesteps on GDP is slower than
   # scaling out spatially, it would make sense to do queries with as big
   # of a spatial resolution as GDP will handle.
-  tar_target(grid_tiles_sf, construct_grid_tiles(grid_params, tile_dim=10)),
+  tar_target(grid_tiles_sf, construct_grid_tiles(grid_params, tile_dim=15)),
 
   # Reconstruct GCM grid using grid parameters from GDP defined above
   tar_target(grid_cells_sf, reconstruct_gcm_grid(grid_params)),


### PR DESCRIPTION
Based on @jread-usgs's comment [here](https://github.com/USGS-R/lake-temperature-model-prep/issues/273#issuecomment-1020197209) and since I have to re-download everything anyways, I tested increasing the tile size from 10 to 15. This did speed up the overall download time when I ran a test for on GCM and one year. I also tested the munging for the 15x15 and there is no issue with pivoting that data. Maybe we could do 20x20 in the future (20x20 was still 4 tiles for MN, so I just decided to leave as 15x15 for now). Could always do more testing in the future if we wanted to try bigger tile sizes for #279.

This is barely even a one-liner change and was suggested as being a known way to increase the performance (and was shown to do that here), so I am going to go ahead and merge so that I can use this new tile size in my re-downloads over the weekend.

```r
# Build times for 10x10 tiles
tar_meta(test_download_times_tile_sizes) %>% 
  pull(seconds)/60
[1] 3.936833 # Test 1: 3.94 min to download 9 tiles worth of 358 cells for 1 year, 1 GCM
[1] 4.2195 # Test 2

# Build times for 15x15 tiles
tar_meta(test_download_times_tile_sizes) %>% 
  pull(seconds)/60
[1] 2.887667 # Test 1: 2.88 min to download 4 tiles worth of 358 cells for 1 year, 1 GCM
[1] 2.8155 # Test 2
```

New `query_map_png`:

![query_map](https://user-images.githubusercontent.com/13220910/152615959-41314ddf-f2df-4bdd-86af-ed8646fe1993.png)
