### PR TITLE
Redownload MN GCMs with grid and leap year fix

### DIFF
--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -414,7 +414,6 @@ validate_notaro_units_assumptions <- function(data_in) {
 #' `data_in` that is not `DateTime` or `time(day of year)`.
 convert_notaro_dates <- function(data_in) {
   data_in %>%
-    # select(DateTime, `time(day of year)`, variable) %>%
 
     ### Group data into the different big time chunks by finding and identifying ###
 
@@ -434,7 +433,7 @@ convert_notaro_dates <- function(data_in) {
     # First treat rows for the same variable and time period as a group
     group_by(variable, new_time_period_i) %>%
     # Determine the earliest year in the time period
-    mutate(earliest_year = as.numeric(format(min(DateTime), "%Y"))) %>% # mutate(year_1 = as.numeric(format(min(DateTime), "%Y"))) %>%
+    mutate(earliest_year = as.numeric(format(min(DateTime), "%Y"))) %>%
     # Create groups of the years (`time(day of year)` will cycle through 0:364 for each
     # year, so tick a counter up for every 0 in the column)
     mutate(year_n = cumsum(`time(day of year)` == 0) - 1) %>%

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -28,8 +28,8 @@ reconstruct_gcm_grid <- function(grid_params) {
 #' @param tile_dim single numeric value representing how many grid cells to
 #' group into a single tile. NOTE - sf_make_grid() can only make square grid
 #' polygons. The GCM grid is 217 cells wide by 141 high. With a `tile_dim` of
-#' 10 (tiles = 10 grid cells x 10 grid cells), tiles won't cover full height
-#' of the GCM grid and there will be 7 columns left out on the right and 1 left
+#' 15 (tiles = 15 grid cells x 15 grid cells), tiles won't cover full height
+#' of the GCM grid and there will be 7 columns left out on the right and 5 left
 #' out on the top. Since all of the cells that are missing are fully outside CONUS,
 #' we are OK with dropping for now. If we wanted to include, we would need to
 #' construct two separate `sf` grids and merge.

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -451,7 +451,7 @@ convert_notaro_dates <- function(data_in) {
     mutate(date_initial = as.Date(sprintf("%s-01-01", year_i)) + `time(day of year)`) %>%
     # If the date in the column is a leap day (Feb 29), the dates need to be adjusted by 1 day
     # meaning the 59th day should be Mar 1 not Feb 29.
-    mutate(leap_adjustment = if_else(format(as.Date(DateTime) + `time(day of year)`, "%m-%d") == "02-29", 1, 0)) %>%
+    mutate(leap_adjustment = if_else(format(date_initial, "%m-%d") == "02-29", 1, 0)) %>%
     # Use cumsum to make sure the leap_adjustment is used for every subsequent day of the year following a leap day
     mutate(total_days_to_add = cumsum(leap_adjustment)) %>%
     ungroup() %>% # Reset groups since they are no longer needed

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -457,6 +457,7 @@ convert_notaro_dates <- function(data_in) {
     # Using the initial date created, adjust the days to shift anything in a leap year that follows Feb 29
     mutate(date_corrected = date_initial + total_days_to_add) %>%
 
-    # Keep only the variable and corrected date columns
+    # Keep the variable, corrected date, statistic, and units columns, as well as, any column
+    # whose name only contains numbers (since those should represent all the grid cell's data)
     select(date = date_corrected, matches("[0-9]+"), variable, statistic, units)
 }

--- a/_targets.R
+++ b/_targets.R
@@ -33,7 +33,7 @@ targets_list <- list(
   )),
 
   # Create larger tiles to use for querying GDP with groups of cells.
-  # Constructing tiles to be made of 100 cells in a 10x10 grid.
+  # Constructing tiles to be made of 225 cells in a 15x15 grid.
   # TODO: this can be much larger! JR thinks GDP can handle ~1000 cells
   # at a time. Since marching through timesteps on GDP is slower than
   # scaling out spatially, it would make sense to do queries with as big


### PR DESCRIPTION
More for #273. This uses the new grid from #297 and the new tile size from #298 to redownload the downscaled GCMs. First, this cut the download time down from 16 hours to 9 hrs 🎉. Second, the work described in https://github.com/USGS-R/lake-temperature-model-prep/issues/273#issuecomment-1030234651 and https://github.com/USGS-R/lake-temperature-model-prep/issues/273#issuecomment-1031981599 makes me confident that we have the grid correct. 

I also made adjustments to how we are using the `DateTime` and `time(day of year)` columns returned from GDP to create dates. The GCMs are built assuming that every year has 365 days, so if we just do `mutate(date = as.Date(DateTime)  + time(day of year))`, we end up mismatching our dates because R assumes you want to include Feb 29 if it is a leap year. It was quite the workaround to get something that correctly converts DateTime and the day of year (ranging from 0:364) into the appropriate day and skip any Feb 29ths. It was not aided by the fact that the `DateTime` is supposed to represent the first date of the current year but is quite messy when returned from GDP and sometimes you have values like `1984-12-31 23:15:03` representing the first day of 1985. For this reason, I had to implement some interesting code that figured out the actual first day for the data, then added one more day to dates after Feb 28 if it was a leap year in order to correctly shift dates to not include Feb 29 ever. I confirmed that this works by comparing one lake's data from my build of this pipeline to that of the [Winslow 2017 release](https://www.sciencebase.gov/catalog/item/57d30fd1e4b0571647d113e7) GCMs in https://github.com/USGS-R/lake-temperature-model-prep/issues/273#issuecomment-1032031775.

Unfortunately, the target for cleaning all the GCMs went from taking 2.5 minutes to just over 5 minutes after these leap year changes (not surprised due to the grouping etc that goes on). However, given that the download takes 9 hrs still, I felt like 5 minutes wasn't worth fretting over for now. Using `data.table` functions (or a hybrid approach with [`dtplyr`](https://dtplyr.tidyverse.org/)) could probably give us some gains, but I didn't want to spend too much time on optimizing now, especially with the looming deadline and without having it reviewed first.