### PR TITLE
Edit query map for use in data release - rename and add tile numbers

### DIFF
--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -178,6 +178,10 @@ map_query <- function(out_file, lake_cell_tile_xwalk, query_tiles, query_cells, 
   grid_tiles <- grid_tiles %>%
     filter(tile_no %in% query_tiles)
 
+  tile_labels <- grid_tiles %>%
+    mutate(bbox=split(.,1:nrow(grid_tiles)) %>% purrr::map(sf::st_bbox)) %>%
+    unnest_wider(bbox)
+
   grid_cells <- grid_cells %>%
     filter(cell_no %in% query_cells) %>%
     left_join(lakes_per_cell)
@@ -185,7 +189,10 @@ map_query <- function(out_file, lake_cell_tile_xwalk, query_tiles, query_cells, 
   query_plot <- ggplot() +
     geom_sf(data = grid_cells, aes(fill = nlakes)) +
     scico::scale_fill_scico(palette = "batlow", direction = -1) +
-    geom_sf(data = grid_tiles, fill = NA, size = 2)
+    geom_sf(data = grid_tiles, fill = NA, size = 2) +
+    geom_text(data = tile_labels, aes(label=tile_no,x=xmin, y=ymax), size=8, nudge_x = 30000, nudge_y = -30000) +
+    theme(axis.title.y=element_blank(),
+        axis.title.x=element_blank())
 
   # save file
   ggsave(out_file, query_plot, width=10, height=8, dpi=300)

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -170,7 +170,7 @@ get_lake_cell_tile_xwalk <- function(lake_centroids, grid_cells, cell_tile_xwalk
 #' @return a png of the mapped grid cells, symbolized by n_lakes per cell, and the grid tiles
 # TODO: This function to should be 1) moved to 8_viz, and 2) made so that it only rebuilds if
 # new cells will be plotted.
-map_query <- function(out_file, lake_cell_tile_xwalk, query_tiles, query_cells, grid_tiles, grid_cells) {
+map_tiles_cells <- function(out_file, lake_cell_tile_xwalk, query_tiles, query_cells, grid_tiles, grid_cells) {
   lakes_per_cell <- lake_cell_tile_xwalk %>%
     group_by(cell_no) %>%
     summarize(nlakes = n())
@@ -179,23 +179,23 @@ map_query <- function(out_file, lake_cell_tile_xwalk, query_tiles, query_cells, 
     filter(tile_no %in% query_tiles)
 
   tile_labels <- grid_tiles %>%
-    mutate(bbox=split(.,1:nrow(grid_tiles)) %>% purrr::map(sf::st_bbox)) %>%
+    mutate(bbox=split(.,tile_no) %>% purrr::map(sf::st_bbox)) %>%
     unnest_wider(bbox)
 
   grid_cells <- grid_cells %>%
     filter(cell_no %in% query_cells) %>%
     left_join(lakes_per_cell)
 
-  query_plot <- ggplot() +
+  tile_cell_plot <- ggplot() +
     geom_sf(data = grid_cells, aes(fill = nlakes)) +
     scico::scale_fill_scico(palette = "batlow", direction = -1) +
     geom_sf(data = grid_tiles, fill = NA, size = 2) +
-    geom_text(data = tile_labels, aes(label=tile_no,x=xmin, y=ymax), size=8, nudge_x = 30000, nudge_y = -30000) +
+    geom_text(data = tile_labels, aes(label=tile_no,x=xmin, y=ymax), size=8, nudge_x = 15000, nudge_y = -30000, hjust = 0) +
     theme(axis.title.y=element_blank(),
         axis.title.x=element_blank())
 
   # save file
-  ggsave(out_file, query_plot, width=10, height=8, dpi=300)
+  ggsave(out_file, tile_cell_plot, width=10, height=8, dpi=300)
 
   return(out_file)
 }

--- a/_targets.R
+++ b/_targets.R
@@ -108,9 +108,9 @@ targets_list <- list(
   ##### Create an image showing the full query, with n_lakes per cell #####
 
   tar_target(
-    query_map_png,
+    tile_cell_map_png,
     map_query(
-      out_file = '7_drivers_munge/out/query_map.png',
+      out_file = '7_drivers_munge/out/tile_cell_map.png',
       lake_cell_tile_xwalk = lake_cell_tile_xwalk_df,
       query_tiles = query_tiles,
       query_cells = query_cells,

--- a/_targets.R
+++ b/_targets.R
@@ -109,7 +109,7 @@ targets_list <- list(
 
   tar_target(
     tile_cell_map_png,
-    map_query(
+    map_tiles_cells(
       out_file = '7_drivers_munge/out/tile_cell_map.png',
       lake_cell_tile_xwalk = lake_cell_tile_xwalk_df,
       query_tiles = query_tiles,


### PR DESCRIPTION
Modify code to generate `query_map_png`, so that the tiles are numbered on the map, and rename it to `tile_cell_map_png` to better describe what it shows. Given that we are [currently packaging](https://github.com/USGS-R/lake-temperature-process-models/blob/main/3_extract.R#L13-L30) up the prediction feather files by tile ([PR to make approach more flexible](https://github.com/USGS-R/lake-temperature-process-models/pull/26)), we can use this in the draft [data release](https://www.sciencebase.gov/catalog/item/6206d3c2d34ec05caca53071). As we finalize the data release, we may want to either revise this map or make a new version, since the tiles may not be relevant to how the final predictions are packaged.