### PR TITLE
Update scipiper yaml and rebuild indicator file for pipeline

### DIFF
--- a/7_drivers_munge.yml
+++ b/7_drivers_munge.yml
@@ -53,4 +53,5 @@ targets:
   7_drivers_munge/out/7_GCM_driver_files.ind:
     command: build_GCM_pipeline(
       target_name,
-      "2_crosswalk_munge/out/centroid_lakes_sf.rds.ind")
+      "2_crosswalk_munge/out/centroid_lakes_sf.rds.ind",
+      "2_crosswalk_munge/out/lake_to_state_xwalk.rds.ind")

--- a/7_drivers_munge/out/7_GCM_driver_files.ind
+++ b/7_drivers_munge/out/7_GCM_driver_files.ind
@@ -1,3 +1,9 @@
-2_crosswalk_munge/out/centroid_lakes_sf.rds: 7dfbdba8229eeeac0516e1cd264928a3
-7_drivers_munge/out/centroid_map.png: 9f3d5ffa593039e58cd805d59b0f018e
+7_drivers_munge/out/GCM_ACCESS.nc: e15a972d4f29baa831beace8c81fcdd5
+7_drivers_munge/out/GCM_CNRM.nc: 2edeaa0f17e23e0728596e6b5cc94311
+7_drivers_munge/out/GCM_GFDL.nc: 716ccaee0b007e45b65e59fced4d8889
+7_drivers_munge/out/GCM_IPSL.nc: f519c51672dbcec18d0d14e461e08e21
+7_drivers_munge/out/GCM_MIROC5.nc: 39438a2e4e9ee5cf21dbe95603940e79
+7_drivers_munge/out/GCM_MRI.nc: 857e71386f0c25b6c1a6da7c537a5444
+7_drivers_munge/out/lake_cell_tile_xwalk.csv: 223ca8fc412f831a0f3555f31e03f325
+7_drivers_munge/out/tile_cell_map.png: c7906020b45fc62d8b82ff8145c323bd
 

--- a/_targets.R
+++ b/_targets.R
@@ -256,7 +256,7 @@ targets_list <- list(
   ##### Get list of final output files to link back to scipiper pipeline #####
   tar_target(
     gcm_files_out,
-    c(gcm_nc, lake_cell_xwalk_csv)
+    c(gcm_nc, lake_cell_tile_xwalk_csv, tile_cell_map_png)
   )
 )
 

--- a/_targets.R
+++ b/_targets.R
@@ -256,7 +256,8 @@ targets_list <- list(
   ##### Get list of final output files to link back to scipiper pipeline #####
   tar_target(
     gcm_files_out,
-    c(gcm_nc, lake_cell_tile_xwalk_csv, tile_cell_map_png)
+    c(gcm_nc, lake_cell_tile_xwalk_csv, tile_cell_map_png),
+    format = 'file'
   )
 )
 

--- a/build/status/N19kcml2ZXJzX211bmdlL291dC83X0dDTV9kcml2ZXJfZmlsZXMuaW5k.yml
+++ b/build/status/N19kcml2ZXJzX211bmdlL291dC83X0dDTV9kcml2ZXJfZmlsZXMuaW5k.yml
@@ -1,12 +1,13 @@
 version: 0.3.0
 name: 7_drivers_munge/out/7_GCM_driver_files.ind
 type: file
-hash: ff16b70a357f12e2e17f30ae44375844
-time: 2021-11-12 15:26:34 UTC
+hash: 858bd8284a80aba5e6dcdbdec1c7e8b0
+time: 2022-02-16 16:36:29 UTC
 depends:
-  2_crosswalk_munge/out/centroid_lakes_sf.rds.ind: 3863d7a358596a912c2d87fca11e2d37
+  2_crosswalk_munge/out/centroid_lakes_sf.rds.ind: 7ffeb0780958d841e25ccdbe6b502cca
+  2_crosswalk_munge/out/lake_to_state_xwalk.rds.ind: 95fbdd8997482db0886c02d96d1041fb
 fixed: ecd2ace6bd2c040576a545a1d62e37ad
 code:
   functions:
-    build_GCM_pipeline: 63276e5fe8dbcdadaf1f253d64bc92d8
+    build_GCM_pipeline: 3f14da5bfecc1e208558b52bcac71015
 


### PR DESCRIPTION
* Add in `'2_crosswalk_munge/out/lake_to_stat_xwalk.rds.ind'` as a dependecy for `'7_divers_munge/out/7_GCM_driver_files.ind'` (the scipiper indicator file for the output files from the `gcm_driver_data_munge_pipeline` `targets` sub-pipeline
* Add `tile_cell_map_png` target to the `gcm_files_out` target and classify it as a file target
* Rebuild the `'7_divers_munge/out/7_GCM_driver_files.ind'` indicator file