### PR TITLE
Only .gitignore 7_drivers_munge/out png files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ rsconnect/
 3_params_fetch/in/*.csv
 3_params_fetch/out/*.csv
 6_drivers/log/feather/*.feather.ind
-7_drivers_munge/in/*
+7_drivers_munge/out/*.png
 7_drivers_munge/out/*.csv
 7_drivers_munge/out/*.csv.ind
 6_drivers/log/feather/cellgroup*.yml
@@ -56,7 +56,6 @@ rsconnect/
 *.xml
 *.xlsx
 *.Rdata
-*.png
 # "in" cooperator data
 /6_temp_coop_fetch/in/*
 !/6_temp_coop_fetch/in/*.ind


### PR DESCRIPTION
Fix `.gitignore` file to only ignore `.png` files in `7_drivers_munge/out` and remove `.gitignore` line for `7_drivers_munge/in` that doesn't exist.