### PR TITLE
GCM munging - address NA cells

### DIFF
--- a/7_drivers_munge/out/7_GCM_driver_files.ind
+++ b/7_drivers_munge/out/7_GCM_driver_files.ind
@@ -1,9 +1,9 @@
-7_drivers_munge/out/GCM_ACCESS.nc: e15a972d4f29baa831beace8c81fcdd5
-7_drivers_munge/out/GCM_CNRM.nc: 2edeaa0f17e23e0728596e6b5cc94311
-7_drivers_munge/out/GCM_GFDL.nc: 716ccaee0b007e45b65e59fced4d8889
-7_drivers_munge/out/GCM_IPSL.nc: f519c51672dbcec18d0d14e461e08e21
-7_drivers_munge/out/GCM_MIROC5.nc: 39438a2e4e9ee5cf21dbe95603940e79
-7_drivers_munge/out/GCM_MRI.nc: 857e71386f0c25b6c1a6da7c537a5444
-7_drivers_munge/out/lake_cell_tile_xwalk.csv: 223ca8fc412f831a0f3555f31e03f325
-7_drivers_munge/out/tile_cell_map.png: c7906020b45fc62d8b82ff8145c323bd
+7_drivers_munge/out/GCM_ACCESS.nc: 8b9e3833fe9bd6838a96b489883c0b8f
+7_drivers_munge/out/GCM_CNRM.nc: 1555a0c6639af1a91eeb8c5d35c3fb4b
+7_drivers_munge/out/GCM_GFDL.nc: fa700a436f0385fafd3c7cf15325f0ca
+7_drivers_munge/out/GCM_IPSL.nc: 7c4686ebbc8d17e1c89bbd506ab1ee9b
+7_drivers_munge/out/GCM_MIROC5.nc: 2ddc4143a7c446eb62c0c43587623fd4
+7_drivers_munge/out/GCM_MRI.nc: 391ee0c4ad895254b9ee1b8f99f0ea7d
+7_drivers_munge/out/lake_cell_tile_xwalk.csv: 3ca427c26907e5c3c41630883789fd7e
+7_drivers_munge/out/tile_cell_map.png: 7581b862d79ad8c5b1a696637f6c7f74
 

--- a/7_drivers_munge/out/7_GCM_driver_files.ind
+++ b/7_drivers_munge/out/7_GCM_driver_files.ind
@@ -4,6 +4,6 @@
 7_drivers_munge/out/GCM_IPSL.nc: 7c4686ebbc8d17e1c89bbd506ab1ee9b
 7_drivers_munge/out/GCM_MIROC5.nc: 2ddc4143a7c446eb62c0c43587623fd4
 7_drivers_munge/out/GCM_MRI.nc: 391ee0c4ad895254b9ee1b8f99f0ea7d
-7_drivers_munge/out/lake_cell_tile_xwalk.csv: 3ca427c26907e5c3c41630883789fd7e
-7_drivers_munge/out/tile_cell_map.png: 7581b862d79ad8c5b1a696637f6c7f74
+7_drivers_munge/out/lake_cell_tile_xwalk.csv: d4babe72be11fd5567c6564d3fbb4b7b
+7_drivers_munge/out/query_tile_cell_map.png: c7906020b45fc62d8b82ff8145c323bd
 

--- a/7_drivers_munge/out/7_GCM_driver_files.ind
+++ b/7_drivers_munge/out/7_GCM_driver_files.ind
@@ -4,6 +4,6 @@
 7_drivers_munge/out/GCM_IPSL.nc: 7c4686ebbc8d17e1c89bbd506ab1ee9b
 7_drivers_munge/out/GCM_MIROC5.nc: 2ddc4143a7c446eb62c0c43587623fd4
 7_drivers_munge/out/GCM_MRI.nc: 391ee0c4ad895254b9ee1b8f99f0ea7d
-7_drivers_munge/out/lake_cell_tile_xwalk.csv: d4babe72be11fd5567c6564d3fbb4b7b
+7_drivers_munge/out/lake_cell_tile_xwalk.csv: 7477501bbe43d7cc244541b3e98da1d1
 7_drivers_munge/out/query_tile_cell_map.png: c7906020b45fc62d8b82ff8145c323bd
 

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -400,7 +400,7 @@ munge_notaro_to_glm <- function(in_file, gcm_name, tile_no) {
   raw_data_excl_na_cells <- select(raw_data, -all_of(na_cell_colnames))
 
   # Munge the raw data for all cells that returned data
-  daily_data <- raw_data_excl_na_cells %>%
+  munged_data <- raw_data_excl_na_cells %>%
 
     # Create a column with the actual date
     convert_notaro_dates() %>%
@@ -450,19 +450,19 @@ munge_notaro_to_glm <- function(in_file, gcm_name, tile_no) {
            Snow
     )
 
-  # Save the daily data
+  # Save the munged data
   out_file <- gsub("_raw.feather", "_munged.feather", in_file)
-  arrow::write_feather(daily_data, out_file)
+  arrow::write_feather(munged_data, out_file)
 
   # Create an output tibble documenting which cells are and are not
   # missing data, noting the gcm name and tile_no
   cell_info <- bind_rows(
-    tibble(cell_no = unique(daily_data$cell_no), missing_data = FALSE),
+    tibble(cell_no = unique(munged_data$cell_no), missing_data = FALSE),
     tibble(cell_no = as.numeric(na_cell_colnames), missing_data = TRUE)) %>%
     mutate(gcm = gcm_name, tile_no = tile_no, .before=1) %>%
     arrange(cell_no)
 
-  return(list(file_out = out_file, cell_info=cell_info))
+  return(list(list(file_out = out_file, cell_info=cell_info)))
 }
 
 #' @title Check that units for variables downloaded match our assumptions.

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -357,8 +357,8 @@ download_gcm_data <- function(out_file_template, query_geom,
 #' @param in_file filepath to a feather file containing the hourly geoknife
 #' data, named with the the gcm, dates, and tile number as
 #' '7_drivers_munge/tmp/7_GCM_{gcm_name}_{projection_period}_tile{tile_no}_raw.feather'
-#' @param gcm_name name of one of the six GCMs, for which data is being read
-#' @param tile_no id of the tile polygon used to group the cells for the data query
+#' @param gcm_names names of the six GCMs
+#' @param query_tiles vector of tile ids used in query to GDP
 #' @value a table saved as a feather file with the following columns:
 #' `time`: class Date denoting a single day
 #' `cell_no`: a numeric value indicating which cell in the grid that the data
@@ -380,7 +380,10 @@ download_gcm_data <- function(out_file_template, query_geom,
 #' being munged, `tile_no` the tile for which data are being munged, `cell_no` for the cell
 #' number, and `missing_data` - a T/F logical indicating whether or not the cell is
 #' missing data for *any* variable for the gcm for which data are being munged.
-munge_notaro_to_glm <- function(in_file, gcm_name, tile_no) {
+munge_notaro_to_glm <- function(in_file, gcm_names, query_tiles) {
+  # Pull gcm name and tile_no
+  gcm_name <- str_extract(in_file, paste(gcm_names, collapse="|"))
+  tile_no <- str_extract(in_file, paste(query_tiles, collapse="|"))
 
   raw_data <- arrow::read_feather(in_file)
 

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -345,22 +345,6 @@ download_gcm_data <- function(out_file_template, query_geom,
   return(out_file)
 }
 
-#' @title Pull out individual file information from a dynamically mapped target
-#' @description Use a dynamically mapped target to extract information about
-#' the individual branch files to build a table that can group files and then
-#' trigger rebuilds when individual files within a group change.
-#' @param dynamic_branch_names character vector of the names of each branch created
-#' from running `names()` using the target dynamically branched target as input.
-#' @return a tibble with three columns (`name` = target name of the branch, `path`
-#' = character string of the file created by that branch, and `data` = hash code
-#' indicating the current state of the file) and a row for each branch.
-build_branch_file_hash_table <- function(dynamic_branch_names) {
-  # Get metadata for all the branches of the dynamic target
-  tar_meta(all_of(dynamic_branch_names), c("path", "data")) %>%
-    # There is just one path per branch, so remove the `list` format from this column
-    unnest(path)
-}
-
 #' @title Convert Notaro GCM data to GLM-ready data
 #' @description The final GCM driver data needs certain column names and units
 #' to be used for GLM. This function converts GCM variables into appropriate

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -158,22 +158,22 @@ get_lake_cell_tile_spatial_xwalk <- function(lake_centroids, grid_cells, cell_ti
 #' @title Adjust the lake-cell-tile xwalk by matching lakes to the queried cells
 #' that returned data.
 #' @description Using lake centroids, this spatially matches lakes to query cells
-#' that returned data. The preference is to  match lakes to non-nan cells with the
-#' same y value (within the same row) as the cell that the lake falls within (which
+#' that returned data. If the cell that the lake falls within is not missing data,
+#' the lake will be matched to the cell that it falls within. If the cell that the
+#' lake falls within is missing data, the lake will be matched to a cell that did
+#' return data. The preference is to match such lakes to non-nan cells with the
+#' same y value (within the same row) as the cell that the lake falls within (as
 #' is captured in the `spatial_xwalk` returned by `get_lake_cell_tile_spatial_xwalk`).
-#' If the cell that the lake falls within is not missing data, the lake will be
-#' matched to the cell that it falls within. If the cell that the lake falls within
-#' is missing data, the lake will be matched to a cell that did return data,
-#' preferably one within the same grid row. However, we do not want to match lakes to
-#' cells that are too far in the x direction (too many columns away) from the cell that
-#' the lake falls within. The variable `x_buffer` sets the maximum allowable x-distance
-#' (number of columns) between the cell the lake is in and any potential non-nan cells
-#' that could be matched to the lake. If no non-nan cells are in the same row as the
-#' cell that is missing data, or if there are no non-nan cells in that same row that
-#' are within the specified x-distance, the lake will be matched to the non-nan cell
-#' with the centroid closest to the lake centroid, regardless of y value. The output of
-#' this function will only differ from the output of `get_lake_cell_tile_spatial_xwalk()`
-#' for those lakes that fell within cells that did not return data.
+#' However, we do not want to match lakes to cells that are too far in the x direction
+#' (too many columns away) from the cell that the lake falls within. The variable
+#' `x_buffer` sets the maximum allowable x-distance (number of columns) between the
+#' cell the lake is in and any potential non-nan cells that could be matched to the
+#' lake. If no non-nan cells are in the same row as the cell that is missing data,
+#' or if there are no non-nan cells in that same row that are within the specified
+#' x-distance, the lake will be matched to the non-nan cell with the centroid closest
+#' to the lake centroid, regardless of y value. The output of this function will only
+#' differ from the output of `get_lake_cell_tile_spatial_xwalk()` for those lakes that
+#' fell within cells that did not return data.
 #' @param spatial_xwalk mapping of which lakes are in which cells and tiles,
 #' based on a spatial join
 #' @param lake_centroids an `sf` object of points representing the lake

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -209,9 +209,11 @@ adjust_lake_cell_tile_xwalk <- function(spatial_xwalk, lake_centroids, query_cel
 
 #' @title Map the tiles and cells
 #' @description Map the grid cells w/ lakes (symbolized by n_lakes per cell) and grid tiles
-#' from the provided lake_cell_tile_xwalk
+#' included in the GDP query
 #' @param out_file name of output png file
 #' @param lake_cell_tile_xwalk mapping of which lakes are in which cells and tiles
+#' @param query_tiles vector of tiles that contain `query_cells`
+#' @param query_cells vector of cells that contain lakes
 #' @param grid_tiles an`sf` object with polygons representing the
 #' groups of grid cells. Must contain a `tile_no` column which has
 #' the id of each of the tile polygons.
@@ -221,20 +223,20 @@ adjust_lake_cell_tile_xwalk <- function(spatial_xwalk, lake_centroids, query_cel
 #' @return a png of the xwalk grid cells, symbolized by n_lakes per cell, and the grid tiles
 # TODO: This function to should be 1) moved to 8_viz, and 2) made so that it only rebuilds if
 # new cells will be plotted.
-map_tiles_cells <- function(out_file, lake_cell_tile_xwalk, grid_tiles, grid_cells) {
+map_tiles_cells <- function(out_file, lake_cell_tile_xwalk, query_tiles, query_cells, grid_tiles, grid_cells) {
   lakes_per_cell <- lake_cell_tile_xwalk %>%
     group_by(cell_no) %>%
     summarize(nlakes = n())
 
   grid_tiles <- grid_tiles %>%
-    filter(tile_no %in% lake_cell_tile_xwalk$tile_no)
+    filter(tile_no %in% query_tiles)
 
   tile_labels <- grid_tiles %>%
     mutate(bbox=split(.,tile_no) %>% purrr::map(sf::st_bbox)) %>%
     unnest_wider(bbox)
 
   grid_cells <- grid_cells %>%
-    filter(cell_no %in% lake_cell_tile_xwalk$cell_no) %>%
+    filter(cell_no %in% query_cells) %>%
     left_join(lakes_per_cell)
 
   tile_cell_plot <- ggplot() +

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -194,36 +194,34 @@ get_lake_cell_tile_data_xwalk <- function(lake_centroids, query_cell_centroids, 
   return(lake_cells_with_data_tiles_join)
 }
 
-#' @title Map the query tiles and cells
+#' @title Map the tiles and cells
 #' @description Map the grid cells w/ lakes (symbolized by n_lakes per cell) and grid tiles
-#' included in the GDP query
+#' from the provided lake_cell_tile_xwalk
 #' @param out_file name of output png file
 #' @param lake_cell_tile_xwalk mapping of which lakes are in which cells and tiles
-#' @param query_tiles vector of tiles that contain `query_cells`
-#' @param query_cells vector of cells that contain lakes
 #' @param grid_tiles an`sf` object with polygons representing the
 #' groups of grid cells. Must contain a `tile_no` column which has
 #' the id of each of the tile polygons.
 #' @param grid_cells an `sf` object with square polygons representing the
 #' grid cells. Must contain a `cell_no` column which has
 #' the id of each of the cell polygons.
-#' @return a png of the queried grid cells, symbolized by n_lakes per cell, and the grid tiles
+#' @return a png of the xwalk grid cells, symbolized by n_lakes per cell, and the grid tiles
 # TODO: This function to should be 1) moved to 8_viz, and 2) made so that it only rebuilds if
 # new cells will be plotted.
-map_query_tiles_cells <- function(out_file, lake_cell_tile_xwalk, query_tiles, query_cells, grid_tiles, grid_cells) {
+map_tiles_cells <- function(out_file, lake_cell_tile_xwalk, grid_tiles, grid_cells) {
   lakes_per_cell <- lake_cell_tile_xwalk %>%
     group_by(cell_no) %>%
     summarize(nlakes = n())
 
   grid_tiles <- grid_tiles %>%
-    filter(tile_no %in% query_tiles)
+    filter(tile_no %in% lake_cell_tile_xwalk$tile_no)
 
   tile_labels <- grid_tiles %>%
     mutate(bbox=split(.,tile_no) %>% purrr::map(sf::st_bbox)) %>%
     unnest_wider(bbox)
 
   grid_cells <- grid_cells %>%
-    filter(cell_no %in% query_cells) %>%
+    filter(cell_no %in% lake_cell_tile_xwalk$cell_no) %>%
     left_join(lakes_per_cell)
 
   tile_cell_plot <- ggplot() +

--- a/_targets.R
+++ b/_targets.R
@@ -199,7 +199,7 @@ targets_list <- list(
   # to determine what meteorological data to pull for each lake.
   tar_target(lake_cell_tile_xwalk_df,
              adjust_lake_cell_tile_xwalk(lake_cell_tile_spatial_xwalk_df, query_lake_centroids_sf,
-                                         query_cell_centroids_sf, glm_ready_gcm_data_cell_info)
+                                         query_cell_centroids_sf, glm_ready_gcm_data_cell_info, x_buffer=3)
              ),
 
   # Save the revised lake-cell-tile mapping for use in `lake-temperature-process-models`

--- a/_targets.R
+++ b/_targets.R
@@ -171,7 +171,7 @@ targets_list <- list(
   # beneath the surface to store that object target.
   tar_target(
     glm_ready_gcm_data_list,
-    munge_notaro_to_glm(gcm_data_raw_feather, gcm_names, query_tiles),
+    munge_gdp_output(gcm_data_raw_feather, gcm_names, query_tiles),
     pattern = map(gcm_data_raw_feather)
   ),
 

--- a/_targets.R
+++ b/_targets.R
@@ -106,6 +106,8 @@ targets_list <- list(
     map_tiles_cells(
       out_file = '7_drivers_munge/out/query_tile_cell_map.png',
       lake_cell_tile_xwalk = lake_cell_tile_spatial_xwalk_df,
+      query_tiles = query_tiles,
+      query_cells = query_cells,
       grid_tiles = grid_tiles_sf,
       grid_cells = grid_cells_sf
     ),
@@ -207,18 +209,6 @@ targets_list <- list(
     return(out_file)
   }, format = 'file'),
 
-  # Map the new lake-cell-tile xwalk
-  tar_target(
-    tile_cell_map_png,
-    map_tiles_cells(
-      out_file = '7_drivers_munge/out/tile_cell_map.png',
-      lake_cell_tile_xwalk = lake_cell_tile_xwalk_df,
-      grid_tiles = grid_tiles_sf,
-      grid_cells = grid_cells_sf
-    ),
-    format='file'
-  ),
-
   # Create feather files that can be used in the GLM pipeline without
   # having to be munged and extracted via NetCDF. Temporary solution
   # while we work out some NetCDF challenges.
@@ -305,7 +295,7 @@ targets_list <- list(
   ##### Get list of final output files to link back to scipiper pipeline #####
   tar_target(
     gcm_files_out,
-    c(gcm_nc, lake_cell_tile_xwalk_csv, tile_cell_map_png),
+    c(gcm_nc, lake_cell_tile_xwalk_csv, query_tile_cell_map_png),
     format = 'file'
   )
 )

--- a/_targets.R
+++ b/_targets.R
@@ -171,8 +171,8 @@ targets_list <- list(
   # beneath the surface to store that object target.
   tar_target(
     glm_ready_gcm_data_list,
-    munge_notaro_to_glm(gcm_data_raw_feather, gcm_names, unique(query_cells_centroids_list_by_tile$tile_no)),
-    pattern = map(gcm_data_raw_feather, cross(query_cells_centroids_list_by_tile, gcm_names, gcm_dates_df))
+    munge_notaro_to_glm(gcm_data_raw_feather, gcm_names, query_tiles),
+    pattern = map(gcm_data_raw_feather)
   ),
 
   # Combine the `file_out` elements of the gcm_ready_gcm_data_list branches

--- a/_targets.R
+++ b/_targets.R
@@ -192,11 +192,13 @@ targets_list <- list(
 
   # Re-do mapping of which lakes are in which cells and tiles, using only the query
   # cells that returned data and did not have missing data for any variables for any GCMs.
-  # Here, each lake is matched to the cell with the centroid that is closest to the
-  # lake centroid. By using only those cells that returned data, we can ensure that lakes
-  # that fell within cells that were missing data are re-assigned to the closest
-  # cell that returned data. This xwalk is being used in `lake-temperature-process-models`
-  # to determine what meteorological data to pull for each lake.
+  # Here, the pool of cells to which lakes can be matched are those cells that returned data,
+  # to ensure that lakes that fell within cells that were missing data are re-assigned to
+  # a cell that returned data. Lakes are preferentially matched to cells within the same
+  # grid row and within `x_buffer` columns from the cell that the lake falls within.
+  # If no cells that returned data meet that criteria, the lake is matched to the closest
+  # cell that did return data, regardless of row. This xwalk is being used in
+  # `lake-temperature-process-models` to determine what meteorological data to pull for each lake.
   tar_target(lake_cell_tile_xwalk_df,
              adjust_lake_cell_tile_xwalk(lake_cell_tile_spatial_xwalk_df, query_lake_centroids_sf,
                                          query_cell_centroids_sf, glm_ready_gcm_data_cell_info, x_buffer=3)

--- a/_targets.R
+++ b/_targets.R
@@ -252,11 +252,13 @@ targets_list <- list(
   ),
 
   # Group daily feather files by GCM to map over and include
-  # branch file hashes to trigger rebuilds for groups as needed
+  # file hashes to trigger rebuilds for groups as needed
   tar_target(gcm_data_daily_feather_group_by_gcm,
-              build_branch_file_hash_table(names(glm_ready_gcm_data_feather)) %>%
-               rename(gcm_file = path) %>%
-               mutate(gcm_name = str_extract(gcm_file, paste(gcm_names, collapse="|"))) %>%
+             tibble(
+               gcm_file = glm_ready_gcm_data_feather,
+               data = tools::md5sum(gcm_file),
+               gcm_name = str_extract(gcm_file, paste(gcm_names, collapse="|"))
+             ) %>%
                group_by(gcm_name) %>%
                tar_group(),
              iteration = "group"),

--- a/_targets.R
+++ b/_targets.R
@@ -103,11 +103,9 @@ targets_list <- list(
 
   tar_target(
     query_tile_cell_map_png,
-    map_query_tiles_cells(
+    map_tiles_cells(
       out_file = '7_drivers_munge/out/query_tile_cell_map.png',
       lake_cell_tile_xwalk = lake_cell_tile_xwalk_spatial_df,
-      query_tiles = query_tiles,
-      query_cells = query_cells,
       grid_tiles = grid_tiles_sf,
       grid_cells = grid_cells_sf
     ),
@@ -222,6 +220,18 @@ targets_list <- list(
     return(out_file)
   }, format = 'file'),
 
+  # Map the new lake-cell-tile xwalk
+  tar_target(
+    tile_cell_map_png,
+    map_tiles_cells(
+      out_file = '7_drivers_munge/out/tile_cell_map.png',
+      lake_cell_tile_xwalk = lake_cell_tile_xwalk_data_df,
+      grid_tiles = grid_tiles_sf,
+      grid_cells = grid_cells_sf
+    ),
+    format='file'
+  ),
+
   # Create feather files that can be used in the GLM pipeline without
   # having to be munged and extracted via NetCDF. Temporary solution
   # while we work out some NetCDF challenges.
@@ -306,7 +316,7 @@ targets_list <- list(
   ##### Get list of final output files to link back to scipiper pipeline #####
   tar_target(
     gcm_files_out,
-    c(gcm_nc, lake_cell_tile_xwalk_csv, query_tile_cell_map_png),
+    c(gcm_nc, lake_cell_tile_xwalk_csv, tile_cell_map_png),
     format = 'file'
   )
 )

--- a/_targets.R
+++ b/_targets.R
@@ -135,32 +135,24 @@ targets_list <- list(
     "windspeed_debias" # Wind speed (m/s)
     )),
 
-  # # Download data from GDP for each tile, GCM name, and GCM projection period combination.
-  # # If the cells in a tile don't change, then the tile should not need to rebuild.
-  # tar_target(
-  #   gcm_data_raw_feather,
-  #   download_gcm_data(
-  #     out_file_template = "7_drivers_munge/tmp/7_GCM_%s_%s_tile%s_raw.feather",
-  #     query_geom = query_cells_centroids_list_by_tile,
-  #     gcm_name = gcm_names,
-  #     gcm_projection_period = gcm_dates_df$projection_period,
-  #     query_vars = gcm_query_vars,
-  #     query_dates = c(gcm_dates_df$start_datetime, gcm_dates_df$end_datetime)
-  #   ),
-  #   # TODO: might need to split across variables, too. Once we scale up, our queries
-  #   # might be too large and chunking by variable could help.
-  #   pattern = cross(query_cells_centroids_list_by_tile, gcm_names, gcm_dates_df),
-  #   format = "file",
-  #   error = "continue"
-  # ),
-
-  # FOR NOW, USE LINDSAY'S GLM_DATA_RAW FEATHER FILES, BROUGHT IN MANUALLY
-  # mapping over gcm_names, gcm_dates_df, and query_cells_centroids_list_by_tile
-  # to read in Lindsay's created feather files
-  tar_target(gcm_data_raw_feather,
-             sprintf('7_drivers_munge/tmp/7_GCM_%s_%s_tile%s_raw.feather', gcm_names, gcm_dates_df$projection_period, unique(query_cells_centroids_list_by_tile$tile_no)),
-             format = 'file',
-             pattern = cross(query_cells_centroids_list_by_tile, gcm_names, gcm_dates_df)),
+  # Download data from GDP for each tile, GCM name, and GCM projection period combination.
+  # If the cells in a tile don't change, then the tile should not need to rebuild.
+  tar_target(
+    gcm_data_raw_feather,
+    download_gcm_data(
+      out_file_template = "7_drivers_munge/tmp/7_GCM_%s_%s_tile%s_raw.feather",
+      query_geom = query_cells_centroids_list_by_tile,
+      gcm_name = gcm_names,
+      gcm_projection_period = gcm_dates_df$projection_period,
+      query_vars = gcm_query_vars,
+      query_dates = c(gcm_dates_df$start_datetime, gcm_dates_df$end_datetime)
+    ),
+    # TODO: might need to split across variables, too. Once we scale up, our queries
+    # might be too large and chunking by variable could help.
+    pattern = cross(query_cells_centroids_list_by_tile, gcm_names, gcm_dates_df),
+    format = "file",
+    error = "continue"
+  ),
 
   ##### Munge GDP output into NetCDF files that will feed into GLM #####
 

--- a/build/status/N19kcml2ZXJzX211bmdlL291dC83X0dDTV9kcml2ZXJfZmlsZXMuaW5k.yml
+++ b/build/status/N19kcml2ZXJzX211bmdlL291dC83X0dDTV9kcml2ZXJfZmlsZXMuaW5k.yml
@@ -1,8 +1,8 @@
 version: 0.3.0
 name: 7_drivers_munge/out/7_GCM_driver_files.ind
 type: file
-hash: 858bd8284a80aba5e6dcdbdec1c7e8b0
-time: 2022-02-16 16:36:29 UTC
+hash: 2ad17912ecfe63e205c3f7ca19bcbe6d
+time: 2022-02-23 00:15:10 UTC
 depends:
   2_crosswalk_munge/out/centroid_lakes_sf.rds.ind: 7ffeb0780958d841e25ccdbe6b502cca
   2_crosswalk_munge/out/lake_to_state_xwalk.rds.ind: 95fbdd8997482db0886c02d96d1041fb

--- a/build/status/N19kcml2ZXJzX211bmdlL291dC83X0dDTV9kcml2ZXJfZmlsZXMuaW5k.yml
+++ b/build/status/N19kcml2ZXJzX211bmdlL291dC83X0dDTV9kcml2ZXJfZmlsZXMuaW5k.yml
@@ -1,8 +1,8 @@
 version: 0.3.0
 name: 7_drivers_munge/out/7_GCM_driver_files.ind
 type: file
-hash: 2ad17912ecfe63e205c3f7ca19bcbe6d
-time: 2022-02-23 00:15:10 UTC
+hash: 84f757c73b93bc0d6a7bc7ab8bf7fba4
+time: 2022-02-24 00:41:25 UTC
 depends:
   2_crosswalk_munge/out/centroid_lakes_sf.rds.ind: 7ffeb0780958d841e25ccdbe6b502cca
   2_crosswalk_munge/out/lake_to_state_xwalk.rds.ind: 95fbdd8997482db0886c02d96d1041fb

--- a/build/status/N19kcml2ZXJzX211bmdlL291dC83X0dDTV9kcml2ZXJfZmlsZXMuaW5k.yml
+++ b/build/status/N19kcml2ZXJzX211bmdlL291dC83X0dDTV9kcml2ZXJfZmlsZXMuaW5k.yml
@@ -1,8 +1,8 @@
 version: 0.3.0
 name: 7_drivers_munge/out/7_GCM_driver_files.ind
 type: file
-hash: 84f757c73b93bc0d6a7bc7ab8bf7fba4
-time: 2022-02-24 00:41:25 UTC
+hash: aa92a4bdb8781b9614d1ab0c45ea31a7
+time: 2022-03-02 02:15:20 UTC
 depends:
   2_crosswalk_munge/out/centroid_lakes_sf.rds.ind: 7ffeb0780958d841e25ccdbe6b502cca
   2_crosswalk_munge/out/lake_to_state_xwalk.rds.ind: 95fbdd8997482db0886c02d96d1041fb


### PR DESCRIPTION
Alright - I have a solution in place for the missing data, which fixes #296 

Per Lindsay and my discussion, we landed on an approach that did not change any of the data for cells with missing data, but instead adjusted the lake-cell-tile xwalk so that lakes were matched to only those query cells that returned data, on the basis of which query cell centroid was closest to each lake centroid.

To avoid having to read in the data twice (once in order to determine which cells are missing data, and again to munge the data for cells that are not missing), as I proposed in the [2nd bullet under considerations](https://github.com/USGS-R/lake-temperature-model-prep/issues/296#issuecomment-1045076687) in #296, Lindsay suggested that I try returning a list of two items from `munge_notaro_to_glm()`:
  * `file_out` - The name of the output file of munged data for the given gcm and tile
  * `cell_info` - A tibble with a row for each cell in the given tile, with T/F values for whether or not that cell was missing data

That seemed like a great approach so I set up the `targets` workflow like so:
  * In place of `glm_ready_gcm_data_feather` have `munge_notaro_to_glm()` instead build the target `glm_ready_gcm_data_list`, which has a branch for each tile-gcm combo, and 2 elements for each branch: `file_out` and `cell_info`, as noted above.
  * Then construct `glm_ready_gcm_data_feather` from the `file_out` element of each branch. _Note: this ended up requiring mapping over `glm_ready_gcm_data_list`, as each branch of that upstream target had the two distinct elements, and it was not possible to pull just one element from each branch in one go with `glm_ready_gcm_data_list$file_out`_
  * Similarly, construct a combined tibble, `glm_ready_gcm_data_cell_info` from each of the `cell_info` elements of the branches of `glm_ready_gcm_data_list`. _Note: again this required mapping over the branches of `glm_ready_gcm_data_list`_.
  * Then, once I had that combined tibble, I was able to build `glm_ready_gcm_data_cell_status`, a pivoted version of `glm_ready_gcm_data_cell_info` with a single row per cell, and columns indicating whether or not data was missing for each gcm as well as a final column with the total count of gcms for which data was missing.
  * Then I used that `glm_ready_gcm_data_cell_status` to build the new revised lake-cell-tile xwalk `lake_cell_tile_xwalk_data_df` (the original is renamed to `lake_cell_tile_xwalk_spatial_df`) matching lakes to only those query cells that returned data, based on which query cell centroid is closest to each lake centroid.
    * The lake-cell matching will only differ here from that in `lake_cell_tile_xwalk_spatial_df` for those lakes that fell within cells that were missing data. I checked and, as expected, the two crosswalks differ for 123 lakes, which was [the number of lakes that fell within cells with missing data](https://github.com/USGS-R/lake-temperature-model-prep/issues/296#issuecomment-1045076687)
  * This `lake_cell_tile_xwalk_data_df` now gets saved as `lake_cell_tile_xwalk_csv` to be used in `lake-temperature-process-models` to determine what meteo data to pull for each lake.
  * I also added a target to map the new lake-cell-tile xwalk

_Mapping with the spatial xwalk - represents the number of lakes in each cell used in the GDP query_:
![query_tile_cell_map](https://user-images.githubusercontent.com/54007288/155242574-215e3963-9cca-462e-b555-88651a244d91.png)

_Mapping with the revised xwalk - represents the number of lakes in each cell that will use data from that cell as meteo data for GLM modeling_
![tile_cell_map](https://user-images.githubusercontent.com/54007288/155242589-9490b0ab-246f-49df-807d-a2d3bf39ef44.png)

And the map of missing cells with nearest cells to lakes within missing cells noted in green:
![image](https://user-images.githubusercontent.com/54007288/155242779-feb328ba-c8fc-4acc-8366-92b96009d17b.png)

While I was in the code I also cleaned up some of the function documentation and made the use of `cell_no` consistent throughout (some of the munging code used `cell` instead).