### PR TITLE
Fix out skipnc feather

### DIFF
--- a/_targets.R
+++ b/_targets.R
@@ -178,8 +178,13 @@ targets_list <- list(
   # Combine the `file_out` elements of the gcm_ready_gcm_data_list branches
   # into a single vector of file targets
   tar_target(
+    glm_ready_gcm_data_paths,
+    unlist(glm_ready_gcm_data_list[grepl("file_out", names(glm_ready_gcm_data_list))])
+  ),
+  tar_target(
     glm_ready_gcm_data_feather,
-    unlist(glm_ready_gcm_data_list[grepl("file_out", names(glm_ready_gcm_data_list))]),
+    glm_ready_gcm_data_paths,
+    pattern = map(glm_ready_gcm_data_paths),
     format = "file"
   ),
 

--- a/_targets.R
+++ b/_targets.R
@@ -178,13 +178,9 @@ targets_list <- list(
   # Combine the `file_out` elements of the gcm_ready_gcm_data_list branches
   # into a single vector of file targets
   tar_target(
-    glm_ready_gcm_data_paths,
-    unlist(glm_ready_gcm_data_list[grepl("file_out", names(glm_ready_gcm_data_list))])
-  ),
-  tar_target(
     glm_ready_gcm_data_feather,
-    glm_ready_gcm_data_paths,
-    pattern = map(glm_ready_gcm_data_paths),
+    glm_ready_gcm_data_list$file_out,
+    pattern = map(glm_ready_gcm_data_list),
     format = "file"
   ),
 


### PR DESCRIPTION
Make the `glm_ready_gcm_data_feather` back into a branched target so that the `out_skipnc_feather` target can map over it to build the intermediary feather files.