### PR TITLE
Add figure to show missing cells in GCM driver data pull

### DIFF
--- a/7_drivers_munge.yml
+++ b/7_drivers_munge.yml
@@ -38,7 +38,7 @@ targets:
   # kick off a build). Takes 5 seconds to build if the targets pipeline
   # is up-to-date.
   7_GCM_driver_files_date:
-    command: c(I('2022-06-07'))
+    command: c(I('2022-06-09'))
   
   # This .ind file returns hashes for the files used in `lake-temperature-process-models`
   # plus the PNG file that visualizes the cells & tiles used in the query.

--- a/7_drivers_munge/out/7_GCM_driver_files.ind
+++ b/7_drivers_munge/out/7_GCM_driver_files.ind
@@ -6,5 +6,5 @@
 7_drivers_munge/out/GCM_MRI.nc: 2902d3eb26b5067738d519fede922b7f
 7_drivers_munge/out/lake_cell_tile_xwalk.csv: bb6b236875b17d1c82f3fc74c84be1f7
 7_drivers_munge/out/query_tile_cell_map.png: 6f73763c791bd1298a5e758f0555cb07
-7_drivers_munge/out/query_tile_cell_map_missing.png: ce42d0f049f3d1dedd5f6ef4f7dd5083
+7_drivers_munge/out/query_tile_cell_map_missing.png: 3eb77bf27703372dd348734ac6e7e410
 

--- a/7_drivers_munge/out/7_GCM_driver_files.ind
+++ b/7_drivers_munge/out/7_GCM_driver_files.ind
@@ -5,5 +5,6 @@
 7_drivers_munge/out/GCM_MIROC5.nc: 0eea475e7628a7c83c393f412b9b730a
 7_drivers_munge/out/GCM_MRI.nc: 2902d3eb26b5067738d519fede922b7f
 7_drivers_munge/out/lake_cell_tile_xwalk.csv: bb6b236875b17d1c82f3fc74c84be1f7
-7_drivers_munge/out/query_tile_cell_map.png: 2d35b1d1c14d9b4be5947d345de22a7d
+7_drivers_munge/out/query_tile_cell_map.png: 6f73763c791bd1298a5e758f0555cb07
+7_drivers_munge/out/query_tile_cell_map_missing.png: ce42d0f049f3d1dedd5f6ef4f7dd5083
 

--- a/_targets.R
+++ b/_targets.R
@@ -103,7 +103,7 @@ targets_list <- list(
              iteration = "list"),
 
   ##### Create an image showing the full query, with n_lakes per cell #####
-
+  
   tar_target(
     query_tile_cell_map_png,
     map_tiles_cells(
@@ -205,6 +205,19 @@ targets_list <- list(
              adjust_lake_cell_tile_xwalk(lake_cell_tile_spatial_xwalk_df, query_lake_centroids_sf,
                                          query_cell_centroids_sf, glm_ready_gcm_data_cell_info, x_buffer=3)
              ),
+  
+  ##### Create an image showing missing cells from the query #####
+  tar_target(missing_cells, glm_ready_gcm_data_cell_info %>% filter(missing_data) %>% pull(cell_no)),
+  tar_target(
+    query_tile_cell_map_missing_png,
+    map_missing_cells(
+      out_file = '7_drivers_munge/out/query_tile_cell_map_missing.png',
+      lake_cell_tile_xwalk = lake_cell_tile_xwalk_df,
+      missing_cells = missing_cells,
+      grid_cells = grid_cells_sf
+    ),
+    format='file'
+  ),
 
   # Save the revised lake-cell-tile mapping for use in `lake-temperature-process-models`
   tar_target(lake_cell_tile_xwalk_csv, {
@@ -266,7 +279,7 @@ targets_list <- list(
   ##### Get list of final output files to link back to scipiper pipeline #####
   tar_target(
     gcm_files_out,
-    c(gcm_nc, lake_cell_tile_xwalk_csv, query_tile_cell_map_png),
+    c(gcm_nc, lake_cell_tile_xwalk_csv, query_tile_cell_map_png, query_tile_cell_map_missing_png),
     format = 'file'
   )
 )

--- a/_targets.R
+++ b/_targets.R
@@ -207,7 +207,7 @@ targets_list <- list(
              ),
   
   ##### Create an image showing missing cells from the query #####
-  tar_target(missing_cells, glm_ready_gcm_data_cell_info %>% filter(missing_data) %>% pull(cell_no)),
+  tar_target(missing_cells, glm_ready_gcm_data_cell_info %>% filter(missing_data) %>% pull(cell_no) %>% unique()),
   tar_target(
     query_tile_cell_map_missing_png,
     map_missing_cells(

--- a/build/status/N19kcml2ZXJzX211bmdlL291dC83X0dDTV9kcml2ZXJfZmlsZXMuaW5k.yml
+++ b/build/status/N19kcml2ZXJzX211bmdlL291dC83X0dDTV9kcml2ZXJfZmlsZXMuaW5k.yml
@@ -1,8 +1,8 @@
 version: 0.3.0
 name: 7_drivers_munge/out/7_GCM_driver_files.ind
 type: file
-hash: 98fb94dd4c3daaba43b27af528866584
-time: 2022-06-09 14:59:44 UTC
+hash: 17f30c67b2ab0890d5325054d5cdd8ba
+time: 2022-06-09 15:10:04 UTC
 depends:
   2_crosswalk_munge/out/centroid_lakes_sf.rds.ind: 7ffeb0780958d841e25ccdbe6b502cca
   2_crosswalk_munge/out/lake_to_state_xwalk.rds.ind: 95fbdd8997482db0886c02d96d1041fb

--- a/build/status/N19kcml2ZXJzX211bmdlL291dC83X0dDTV9kcml2ZXJfZmlsZXMuaW5k.yml
+++ b/build/status/N19kcml2ZXJzX211bmdlL291dC83X0dDTV9kcml2ZXJfZmlsZXMuaW5k.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
 name: 7_drivers_munge/out/7_GCM_driver_files.ind
 type: file
-hash: 740bc51e60c620644831edb263e28b12
-time: 2022-06-07 19:09:27 UTC
+hash: 98fb94dd4c3daaba43b27af528866584
+time: 2022-06-09 14:59:44 UTC
 depends:
   2_crosswalk_munge/out/centroid_lakes_sf.rds.ind: 7ffeb0780958d841e25ccdbe6b502cca
   2_crosswalk_munge/out/lake_to_state_xwalk.rds.ind: 95fbdd8997482db0886c02d96d1041fb
-  7_GCM_driver_files_date: 2b38e0e5f3710a4413f32721cb966066
+  7_GCM_driver_files_date: de2b1b8bcaae2acec8d8a3a6ddc26477
 fixed: ecd2ace6bd2c040576a545a1d62e37ad
 code:
   functions:


### PR DESCRIPTION
OK, so we scaled and have the full footprint GCMs (see #346 where we adjusted tile size & filtered to NML only & moved to HPC), but unfortunately, the footprint of the Notaro GCMs stops in the middle of the Dakotas. With how we implemented the code to substitute a cell with data for a cell without works, but it means that cells across the same latitude on opposite sides of the state have the same driver data. We need to think about what we want to do about this issue.

`7_drivers_munge/out/query_tile_cell_map.png`:
![image](https://user-images.githubusercontent.com/13220910/172881903-671073cd-f9ff-48de-8280-ae952613a95b.png)

`7_drivers_munge/out/query_tile_cell_map_missing.png`:
![image](https://user-images.githubusercontent.com/13220910/172881749-a2ea461c-a9c1-4834-8fb2-ef2fd6f59520.png)
