### PR TITLE
Only retain lake cell mapping for lakes within GCM footprint

### DIFF
--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -342,7 +342,7 @@ map_missing_cells <- function(out_file, lake_cell_tile_xwalk, cell_info, grid_ce
     mutate(is_missing_data = cell_no %in% grid_cells_w_o_data)
   
   # Get GCM bounding box
-  data_bbox <- grid_cells %>%
+  gcm_bbox <- grid_cells %>%
     filter(cell_no %in% grid_cells_w_data) %>%   
     st_bbox() %>%
     st_as_sfc() %>%
@@ -358,9 +358,10 @@ map_missing_cells <- function(out_file, lake_cell_tile_xwalk, cell_info, grid_ce
     st_bbox()
 
   # Generate the map
-  missing_cell_plot <- usmap::plot_usmap(fill=NA) +
+  missing_cell_plot <- ggplot() +
+    geom_sf(data = spData::us_states, fill=NA) +
     geom_sf(data = grid_cells_w_o_data_outside_gcm_bbox_sf, fill='grey80', color='grey60') +
-    geom_sf(data = data_bbox, fill=NA, color='dodgerblue') +
+    geom_sf(data = gcm_bbox, fill=NA, color='dodgerblue') +
     geom_sf(data = filter(grid_cells_tomap, is_missing_data), 
             aes(fill = as.character(data_cell_no)), color = NA) +
     geom_sf(data = filter(grid_cells_tomap, !is_missing_data), 
@@ -375,7 +376,9 @@ map_missing_cells <- function(out_file, lake_cell_tile_xwalk, cell_info, grid_ce
             subtitle = paste(
               sprintf("%s cells are being used to fill in missing driver data for %s cells", length(cells_being_used), length(gcm_cells_w_o_data)),
               sprintf("%s queried cells (in grey) fell outside of the GCM footprint (blue box)",length(grid_cells_w_o_data_outside_gcm_bbox)),
-              sep='\n'))    
+              sep='\n')) +
+    theme_void() +
+    theme(legend.position="top")
   
   # save file
   ggsave(out_file, missing_cell_plot, width=10, height=8, dpi=300, bg = "white")


### PR DESCRIPTION
This PR adds in logic to filter out any lakes that fall outside of the GCM footprint before generating the final lake to cell mapping in `adjust_lake_cell_tile_xwalk()`.

Previously, Lindsay's exploration showed that a number of queried cells in North and South Dakota were not returning data and were instead being assigned data from the easternmost parts of those states (see #347):
![query_tile_cell_map_missing_ORIG](https://user-images.githubusercontent.com/54007288/182967049-37c877b7-5f8e-45dc-ab7f-01d4c37b1038.png)

With this PR, those lakes that fall outside [the footprint of the cells that did return data (the GCM footprint)](https://github.com/hcorson-dosch/lake-temperature-model-prep/blob/limit-to-gcm-footprint/7_drivers_munge/src/GCM_driver_utils.R#L209-L218) are [dropped](https://github.com/hcorson-dosch/lake-temperature-model-prep/blob/limit-to-gcm-footprint/7_drivers_munge/src/GCM_driver_utils.R#L220-L222) before the crosswalk is generated and data source cells are assigned for cells that did not return data that are _within_ the GCM footprint:
![query_tile_cell_map_missing](https://user-images.githubusercontent.com/54007288/182971675-057937c1-f13c-4ac3-9b45-5b0f623d0bb3.png)

As before, the total # of queried cells that didn't return data is 342, but now only the 76 that fall within the GCM footprint are being assigned data from a nearby cell. 266 fall outside of the GCM footprint. The exported `lake_cell_tile_xwalk.csv` reflects this, with 266 fewer unique `spatial_cell_no` yet the same # of unique `data_cell_no` as before.

I checked and this resulted in 613 lakes being dropped from the `lake_cell_tile_xwalk_df`

