### PR TITLE
Add exception for lotw

### DIFF
--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -385,7 +385,7 @@ map_missing_cells <- function(out_file, lake_cell_tile_xwalk, cell_info, grid_ce
           legend.position="top") + 
     ggtitle("What cells are missing driver data?", 
             subtitle = paste(
-              sprintf("%s queried cells (hollow, light grey border) returned data", length(grid_cells_w_data)),
+              sprintf("%s queried cells (hollow, light grey border) returned data and have lakes present ", length(grid_cells_w_data)),
               sprintf("%s of those cells (red border) are being used to fill in missing driver data for %s cells", length(cells_being_used), length(gcm_cells_w_o_data)),
               sprintf("%s queried cells (in grey) fell outside of the GCM footprint (blue box)",length(grid_cells_w_o_data_outside_gcm_bbox)),
               sep='\n')) +

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -348,9 +348,12 @@ map_missing_cells <- function(out_file, lake_cell_tile_xwalk, cell_info, grid_ce
     filter(cell_no %in% c(gcm_cells_w_o_data, cells_being_used)) %>% 
     mutate(is_missing_data = cell_no %in% grid_cells_w_o_data)
   
+  # Get spatial info for all grid cells w/ data in the gcm grid
+  grid_cells_w_data_sf <- grid_cells %>%
+    filter(cell_no %in% grid_cells_w_data)
+
   # Get GCM bounding box
-  gcm_bbox <- grid_cells %>%
-    filter(cell_no %in% grid_cells_w_data) %>%   
+  gcm_bbox <- grid_cells_w_data_sf %>%
     st_bbox() %>%
     st_as_sfc() %>%
     st_as_sf()
@@ -358,10 +361,6 @@ map_missing_cells <- function(out_file, lake_cell_tile_xwalk, cell_info, grid_ce
   # Get spatial information for cells w/o data outside of gcm grid
   grid_cells_w_o_data_outside_gcm_bbox_sf <- grid_cells %>% 
     filter(cell_no %in% grid_cells_w_o_data_outside_gcm_bbox)
-
-  # Get spatial info for all grid cells w/ data in the gcm grid
-  grid_cells_w_data_sf <- grid_cells %>%
-    filter(cell_no %in% grid_cells_w_data)
 
   # Limit the map to just the cells we need
   bbox_tomap <- grid_cells %>%

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -217,9 +217,16 @@ adjust_lake_cell_tile_xwalk <- function(spatial_xwalk, lake_centroids, grid_cell
     st_as_sfc() %>%
     st_as_sf()
 
+  # pull out Lake of the Woods. It falls just outside of the bounding box of returned data,
+  # but has lots of data, so we want to keep it in our lake subset
+  lotw <- filter(lake_centroids, site_id=='nhdhr_123319728')
+
   # subset lakes to only those within the bounding box of the returned data
   lake_centroids <- lake_centroids %>%
     st_join(cells_with_data_bbox, join=st_within, left=FALSE)
+
+  # add back in Lake of the Woods
+  lake_centroids <- bind_rows(lake_centroids, lotw)
 
   # match each lake to a cell that returned data. If the cell that the lake falls within
   # is not missing data, the lake will be matched to the cell that it falls within. If the

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -360,7 +360,7 @@ map_missing_cells <- function(out_file, lake_cell_tile_xwalk, cell_info, grid_ce
     filter(cell_no %in% grid_cells_w_o_data_outside_gcm_bbox)
 
   # Get spatial info for all grid cells w/ data in the gcm grid
-  data_cells <- grid_cells %>%
+  grid_cells_w_data_sf <- grid_cells %>%
     filter(cell_no %in% grid_cells_w_data)
 
   # Limit the map to just the cells we need
@@ -371,7 +371,7 @@ map_missing_cells <- function(out_file, lake_cell_tile_xwalk, cell_info, grid_ce
   # Generate the map
   missing_cell_plot <- ggplot() +
     geom_sf(data = spData::us_states, fill=NA) +
-    geom_sf(data = data_cells, fill=NA, color='grey90') +
+    geom_sf(data = grid_cells_w_data_sf, fill=NA, color='grey90') +
     geom_sf(data = grid_cells_w_o_data_outside_gcm_bbox_sf, fill='grey80', color='grey60') +
     geom_sf(data = gcm_bbox, fill=NA, color='dodgerblue') +
     geom_sf(data = filter(grid_cells_tomap, is_missing_data), 

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -359,6 +359,10 @@ map_missing_cells <- function(out_file, lake_cell_tile_xwalk, cell_info, grid_ce
   grid_cells_w_o_data_outside_gcm_bbox_sf <- grid_cells %>% 
     filter(cell_no %in% grid_cells_w_o_data_outside_gcm_bbox)
 
+  # Get spatial info for all grid cells w/ data in the gcm grid
+  data_cells <- grid_cells %>%
+    filter(cell_no %in% grid_cells_w_data)
+
   # Limit the map to just the cells we need
   bbox_tomap <- grid_cells %>%
     filter(cell_no %in% c(grid_cells_w_o_data_outside_gcm_bbox, grid_cells_w_data, gcm_cells_w_o_data, cells_being_used)) %>% 
@@ -367,6 +371,7 @@ map_missing_cells <- function(out_file, lake_cell_tile_xwalk, cell_info, grid_ce
   # Generate the map
   missing_cell_plot <- ggplot() +
     geom_sf(data = spData::us_states, fill=NA) +
+    geom_sf(data = data_cells, fill=NA, color='grey90') +
     geom_sf(data = grid_cells_w_o_data_outside_gcm_bbox_sf, fill='grey80', color='grey60') +
     geom_sf(data = gcm_bbox, fill=NA, color='dodgerblue') +
     geom_sf(data = filter(grid_cells_tomap, is_missing_data), 
@@ -381,7 +386,8 @@ map_missing_cells <- function(out_file, lake_cell_tile_xwalk, cell_info, grid_ce
           legend.position="top") + 
     ggtitle("What cells are missing driver data?", 
             subtitle = paste(
-              sprintf("%s cells are being used to fill in missing driver data for %s cells", length(cells_being_used), length(gcm_cells_w_o_data)),
+              sprintf("%s queried cells (hollow, light grey border) returned data", length(grid_cells_w_data)),
+              sprintf("%s of those cells (red border) are being used to fill in missing driver data for %s cells", length(cells_being_used), length(gcm_cells_w_o_data)),
               sprintf("%s queried cells (in grey) fell outside of the GCM footprint (blue box)",length(grid_cells_w_o_data_outside_gcm_bbox)),
               sep='\n')) +
     theme_void() +


### PR DESCRIPTION
This PR manually adds Lake of the Woods back into the lake subset after all lakes that fall outside of the GCM footprint (including LotW) are filtered out. The cell that it falls within is now assigned a nearby cell to use for data. I modified the map to show all queried cells, which reveals why the cell matched to the cell that contains Lake of the Woods is two rows away, as it was the closest queried cell that returned data:
![query_tile_cell_map_missing](https://user-images.githubusercontent.com/54007288/183773555-c008e755-8494-4749-83c0-77f89783bc95.png)

Fixes #351 


