### PR TITLE
Commit changed pipeline files from rebuilding GCM driver nc files

### DIFF
--- a/7_drivers_munge.yml
+++ b/7_drivers_munge.yml
@@ -38,7 +38,7 @@ targets:
   # kick off a build). Takes 5 seconds to build if the targets pipeline
   # is up-to-date.
   7_GCM_driver_files_date:
-    command: c(I('2022-06-09'))
+    command: c(I('2022-08-22'))
   
   # This .ind file returns hashes for the files used in `lake-temperature-process-models`
   # plus the PNG file that visualizes the cells & tiles used in the query.

--- a/7_drivers_munge/out/7_GCM_driver_files.ind
+++ b/7_drivers_munge/out/7_GCM_driver_files.ind
@@ -1,10 +1,10 @@
-7_drivers_munge/out/GCM_ACCESS.nc: 56a66466b5ffc31c9efe8057d1c26376
-7_drivers_munge/out/GCM_CNRM.nc: 22a83c52c3980ef3f8ccebdc509e07ed
-7_drivers_munge/out/GCM_GFDL.nc: 28678468a074fb72f99f49e134b2c16b
-7_drivers_munge/out/GCM_IPSL.nc: 66a4fb8d1b6439a24b99e082f0fa9a01
-7_drivers_munge/out/GCM_MIROC5.nc: 0eea475e7628a7c83c393f412b9b730a
-7_drivers_munge/out/GCM_MRI.nc: 2902d3eb26b5067738d519fede922b7f
-7_drivers_munge/out/lake_cell_tile_xwalk.csv: bb6b236875b17d1c82f3fc74c84be1f7
+7_drivers_munge/out/GCM_ACCESS.nc: 566bd49f97275016f1f68d1fcd0963c0
+7_drivers_munge/out/GCM_CNRM.nc: ca94ec7d9240b3384b7fcd9816310a6a
+7_drivers_munge/out/GCM_GFDL.nc: b13f80f7bff2ca10abc9fea4080386b0
+7_drivers_munge/out/GCM_IPSL.nc: 8d238a6c7c63df91357e2fa896e36b17
+7_drivers_munge/out/GCM_MIROC5.nc: e0eda43770aed02d1a6ee61c516b9b53
+7_drivers_munge/out/GCM_MRI.nc: 7d1360eb9ea6da7c0ee17899c1d6f71c
+7_drivers_munge/out/lake_cell_tile_xwalk.csv: 4ce108561560d63a3ef1a40e1190c464
 7_drivers_munge/out/query_tile_cell_map.png: 6f73763c791bd1298a5e758f0555cb07
-7_drivers_munge/out/query_tile_cell_map_missing.png: 3eb77bf27703372dd348734ac6e7e410
+7_drivers_munge/out/query_tile_cell_map_missing.png: aa10f7068c6338628f627c9cc9c54523
 

--- a/build/status/N19kcml2ZXJzX211bmdlL291dC83X0dDTV9kcml2ZXJfZmlsZXMuaW5k.yml
+++ b/build/status/N19kcml2ZXJzX211bmdlL291dC83X0dDTV9kcml2ZXJfZmlsZXMuaW5k.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
 name: 7_drivers_munge/out/7_GCM_driver_files.ind
 type: file
-hash: 17f30c67b2ab0890d5325054d5cdd8ba
-time: 2022-06-09 15:10:04 UTC
+hash: 8b6362263f9e1db6c018fa7ca2ab6b47
+time: 2022-08-22 20:02:12 UTC
 depends:
   2_crosswalk_munge/out/centroid_lakes_sf.rds.ind: 7ffeb0780958d841e25ccdbe6b502cca
   2_crosswalk_munge/out/lake_to_state_xwalk.rds.ind: 95fbdd8997482db0886c02d96d1041fb
-  7_GCM_driver_files_date: de2b1b8bcaae2acec8d8a3a6ddc26477
+  7_GCM_driver_files_date: 17451d27dfb37975c669965dac95907f
 fixed: ecd2ace6bd2c040576a545a1d62e37ad
 code:
   functions:


### PR DESCRIPTION
Following the addition of the wind transform code #354, I rebuilt the GCM nc files on Tallgrass.

This PR commits the changed files associated with that rebuild:
* `'7_drivers_munge.yml'` - build date for `targets` sub-pipeline
* `'7_drivers_munge/out/7_GCM_driver_files.ind'` - Indictor file reflecting changes to the `'7_drivers/munge/out/GCM_{}.nc'` files resulting from #354 and changes to `'7_drivers_munge/out/lake_cell_tile_xwalk.csv'` and `'7_drivers_munge/out/query_tile_cell_map_missing.png'` resulting from #350 and #352.
* An updated build status file

[apologies for the PR from my main branch - I forgot to create a new branch on Tallgrass when generating the updated files]