### PR TITLE
Reorder data after wind transform

### DIFF
--- a/7_drivers_munge.yml
+++ b/7_drivers_munge.yml
@@ -38,7 +38,7 @@ targets:
   # kick off a build). Takes 5 seconds to build if the targets pipeline
   # is up-to-date.
   7_GCM_driver_files_date:
-    command: c(I('2022-08-22'))
+    command: c(I('2022-08-23'))
   
   # This .ind file returns hashes for the files used in `lake-temperature-process-models`
   # plus the PNG file that visualizes the cells & tiles used in the query.

--- a/7_drivers_munge/out/7_GCM_driver_files.ind
+++ b/7_drivers_munge/out/7_GCM_driver_files.ind
@@ -1,9 +1,9 @@
-7_drivers_munge/out/GCM_ACCESS.nc: 566bd49f97275016f1f68d1fcd0963c0
-7_drivers_munge/out/GCM_CNRM.nc: ca94ec7d9240b3384b7fcd9816310a6a
-7_drivers_munge/out/GCM_GFDL.nc: b13f80f7bff2ca10abc9fea4080386b0
-7_drivers_munge/out/GCM_IPSL.nc: 8d238a6c7c63df91357e2fa896e36b17
-7_drivers_munge/out/GCM_MIROC5.nc: e0eda43770aed02d1a6ee61c516b9b53
-7_drivers_munge/out/GCM_MRI.nc: 7d1360eb9ea6da7c0ee17899c1d6f71c
+7_drivers_munge/out/GCM_ACCESS.nc: c1a0674de711d12bf42fdc14f7aba236
+7_drivers_munge/out/GCM_CNRM.nc: e2f2f79c1c66bdad6dcd33fec9f3b3cd
+7_drivers_munge/out/GCM_GFDL.nc: a5d31d59e247911cb29289a403d70145
+7_drivers_munge/out/GCM_IPSL.nc: 366fbae399b9ce6e68424cf29c430366
+7_drivers_munge/out/GCM_MIROC5.nc: b2330377521b75c43116fa885029cdb3
+7_drivers_munge/out/GCM_MRI.nc: 4cc3b24a38f6c3f9ddc57b04a5a38add
 7_drivers_munge/out/lake_cell_tile_xwalk.csv: 4ce108561560d63a3ef1a40e1190c464
 7_drivers_munge/out/query_tile_cell_map.png: 6f73763c791bd1298a5e758f0555cb07
 7_drivers_munge/out/query_tile_cell_map_missing.png: aa10f7068c6338628f627c9cc9c54523

--- a/7_drivers_munge/src/GCM_driver_utils.R
+++ b/7_drivers_munge/src/GCM_driver_utils.R
@@ -792,8 +792,10 @@ apply_wind_transform <- function(munged_data_df, wind_transform_info, bin_max = 
   merged_offset_wind[, WindSpeed := new_val]
   merged_offset_wind[, c("low_bound", "new_val", "bin_id") := NULL]
   
-  # Convert back to a data.frame before returning
-  merged_offset_wind_df <- data.table::setDF(merged_offset_wind)
-
+  # Convert back to a data.frame and arrange to be the same order as it was
+  # before (increasing time and cell_no)
+  merged_offset_wind_df <- data.table::setDF(merged_offset_wind) %>% 
+    arrange(time, cell_no)
+  
   return(merged_offset_wind_df)
 }

--- a/build/status/N19kcml2ZXJzX211bmdlL291dC83X0dDTV9kcml2ZXJfZmlsZXMuaW5k.yml
+++ b/build/status/N19kcml2ZXJzX211bmdlL291dC83X0dDTV9kcml2ZXJfZmlsZXMuaW5k.yml
@@ -1,12 +1,12 @@
 version: 0.3.0
 name: 7_drivers_munge/out/7_GCM_driver_files.ind
 type: file
-hash: 8b6362263f9e1db6c018fa7ca2ab6b47
-time: 2022-08-22 20:02:12 UTC
+hash: 6c9255bcf9842cb6190b3928cb2e5043
+time: 2022-08-23 16:48:44 UTC
 depends:
   2_crosswalk_munge/out/centroid_lakes_sf.rds.ind: 7ffeb0780958d841e25ccdbe6b502cca
   2_crosswalk_munge/out/lake_to_state_xwalk.rds.ind: 95fbdd8997482db0886c02d96d1041fb
-  7_GCM_driver_files_date: 17451d27dfb37975c669965dac95907f
+  7_GCM_driver_files_date: 560016ab76a41d66cfcacae8a86f64eb
 fixed: ecd2ace6bd2c040576a545a1d62e37ad
 code:
   functions:


### PR DESCRIPTION
The wind transform function added in #354 reordered the columns and that caused downstream issues in the `lake-temperature-process-models` repo because it assumes the dates are in order and GLM models failed. This should fix that!

I have already run `tar_make()` with these new changes on Tallgrass, so the nc files on Caldera should be updated now. 