### PR TITLE
Add `.secrets/` folder & gitignore it to build data-release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,8 +87,11 @@ build/status/Nl9kcml2ZXJzL2xvZy9mZWF0aGVyL2JveF8*
 # Ignore GCM pipeline intermediate files
 7_drivers_munge/tmp/*
 !7_drivers_munge/tmp/.empty
-
 # Files used for running on HPC
 gcm_sing.out
 *.sif
 tmp/*
+
+# Git ignore any secrets files (used to store GD credentials
+# so that `sc_retrieve()` can be called on Caldera)
+.secrets/*


### PR DESCRIPTION
Need this on Caldera in order to build this data release: https://github.com/padilla410/lake-temp-lstm-static-data-release. Want to ensure that others who use this method will not have credentials accidentally committed, so decided it should go in the main repo.

Self-merging as this does not impact anything else.