### PR TITLE
Prepare for Upcoming DGEC Transition

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+Code of Conduct
+===============
+
+All contributions to - and interactions surrounding - this project will abide by
+the [USGS Code of Scientific Conduct][1].
+
+
+
+[1]: https://www.usgs.gov/office-of-science-quality-and-integrity/fundamental-science-practices

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+Contributing
+============
+
+Contributions are welcome from the community. Questions can be asked on the
+[issues page][1]. Before creating a new issue, please take a moment to search
+and make sure a similar issue does not already exist. If one does exist, you
+can comment (most simply even with just a `:+1:`) to show your support for that
+issue.
+
+If you have direct contributions you would like considered for incorporation
+into the project you can [fork this repository][2] and
+[submit a pull request][3] for review.
+
+
+
+[1]: https://github.com/USGS-R/lake-temperature-model-prep/issues
+[2]: https://help.github.com/articles/fork-a-repo/
+[3]: https://help.github.com/articles/about-pull-requests/

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,0 +1,11 @@
+Disclaimer
+==========
+
+This software is preliminary or provisional and is subject to revision. It is
+being provided to meet the need for timely best science. The software has not
+received final approval by the U.S. Geological Survey (USGS). No warranty,
+expressed or implied, is made by the USGS or the U.S. Government as to the
+functionality of the software and related material nor shall the fact of release
+constitute any such warranty. The software is provided on the condition that
+neither the USGS nor the U.S. Government shall be held liable for any damages
+resulting from the authorized or unauthorized use of the software.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,46 @@
+License
+=======
+
+Unless otherwise noted, This project is in the public domain in the United
+States because it contains materials that originally came from the United
+States Geological Survey, an agency of the United States Department of
+Interior. For more information, see the official USGS copyright policy at
+https://www.usgs.gov/information-policies-and-instructions/copyrights-and-credits
+
+Additionally, we waive copyright and related rights in the work
+worldwide through the CC0 1.0 Universal public domain dedication.
+
+
+CC0 1.0 Universal Summary
+-------------------------
+
+This is a human-readable summary of the
+[Legal Code (read the full text)][1].
+
+
+### No Copyright
+
+The person who associated a work with this deed has dedicated the work to
+the public domain by waiving all of his or her rights to the work worldwide
+under copyright law, including all related and neighboring rights, to the
+extent allowed by law.
+
+You can copy, modify, distribute and perform the work, even for commercial
+purposes, all without asking permission.
+
+
+### Other Information
+
+In no way are the patent or trademark rights of any person affected by CC0,
+nor are the rights that other persons may have in the work or in how the
+work is used, such as publicity or privacy rights.
+
+Unless expressly stated otherwise, the person who associated a work with
+this deed makes no warranties about the work, and disclaims liability for
+all uses of the work, to the fullest extent permitted by applicable law.
+When using or citing the work, you should not imply endorsement by the
+author or the affirmer.
+
+
+
+[1]: https://creativecommons.org/publicdomain/zero/1.0/legalcode

--- a/code.json
+++ b/code.json
@@ -2,7 +2,7 @@
   {
     "name": "lake-temperature-model-prep",
     "organization": "U.S. Geological Survey",
-    "description": "Pipeline #1",
+    "description": "A scipiper pipeline for munging lake temperature data",
     "version": "main",
     "status": "Development",
     "permissions": {
@@ -10,65 +10,30 @@
       "licenses": [
         {
           "name": "Public Domain, CC0-1.0",
-          "URL": "https://github.com/USGS-R/lake-temperature-model-prep/blob/main/LICENSE.md"
+          "URL": "https://github.com/DOI-USGS/lake-temperature-model-prep/raw/main/LICENSE.md"
         }
       ]
     },
-    "homepageURL": "https://github.com/USGS-R/lake-temperature-model-prep/",
-    "downloadURL": "https://github.com/USGS-R/lake-temperature-model-prep/archive/refs/heads/main.zip",
-    "disclaimerURL": "https://github.com/USGS-R/lake-temperature-model-prep/blob/main/DISCLAIMER.md",
-    "repositoryURL": "https://github.com/USGS-R/lake-temperature-model-prep.git",
+    "homepageURL": "https://github.com/DOI-USGS/lake-temperature-model-prep/",
+    "downloadURL": "https://github.com/DOI-USGS/lake-temperature-model-prep/archive/refs/heads/main.zip",
+    "disclaimerURL": "https://github.com/DOI-USGS/lake-temperature-model-prep/raw/main/DISCLAIMER.md",
+    "repositoryURL": "https://github.com/DOI-USGS/lake-temperature-model-prep.git",
     "vcs": "git",
-    "laborHours": -1,
+    "laborHours": 500,
     "tags": [
       "R",
-      "USGS"
+      "USGS",
+	  "scipiper"
     ],
     "languages": [
       "R"
     ],
     "contact": {
-      "name": "jordansread",
-      "email": "FILL ME IN"
+      "name": "Sam Oliver",
+      "email": "soliver@usgs.gov"
     },
     "date": {
-      "metadataLastUpdated": "2023-03-03"
-    }
-  },
-  {
-    "name": "",
-    "organization": "U.S. Geological Survey",
-    "description": "",
-    "version": "v0.0.0",
-    "status": "Ideation",
-    "permissions": {
-      "usageType": "openSource",
-      "licenses": [
-        {
-          "name": "Public Domain, CC0-1.0",
-          "URL": "LICENSE.md"
-        }
-      ]
-    },
-    "homepageURL": "",
-    "downloadURL": "",
-    "disclaimerURL": "",
-    "repositoryURL": "",
-    "vcs": "git",
-    "laborHours": 1,
-    "tags": [
-      "R",
-      "USGS"
-    ],
-    "languages": [
-      "R"
-    ],
-    "contact": {
-      "name": "",
-      "email": ""
-    },
-    "date": {
-      "metadataLastUpdated": "2022-10-16"
+      "metadataLastUpdated": "2023-03-21"
     }
   }
 ]

--- a/code.json
+++ b/code.json
@@ -1,0 +1,74 @@
+[
+  {
+    "name": "lake-temperature-model-prep",
+    "organization": "U.S. Geological Survey",
+    "description": "Pipeline #1",
+    "version": "main",
+    "status": "Development",
+    "permissions": {
+      "usageType": "openSource",
+      "licenses": [
+        {
+          "name": "Public Domain, CC0-1.0",
+          "URL": "https://github.com/USGS-R/lake-temperature-model-prep/blob/main/LICENSE.md"
+        }
+      ]
+    },
+    "homepageURL": "https://github.com/USGS-R/lake-temperature-model-prep/",
+    "downloadURL": "https://github.com/USGS-R/lake-temperature-model-prep/archive/refs/heads/main.zip",
+    "disclaimerURL": "https://github.com/USGS-R/lake-temperature-model-prep/blob/main/DISCLAIMER.md",
+    "repositoryURL": "https://github.com/USGS-R/lake-temperature-model-prep.git",
+    "vcs": "git",
+    "laborHours": -1,
+    "tags": [
+      "R",
+      "USGS"
+    ],
+    "languages": [
+      "R"
+    ],
+    "contact": {
+      "name": "jordansread",
+      "email": "FILL ME IN"
+    },
+    "date": {
+      "metadataLastUpdated": "2023-03-03"
+    }
+  },
+  {
+    "name": "",
+    "organization": "U.S. Geological Survey",
+    "description": "",
+    "version": "v0.0.0",
+    "status": "Ideation",
+    "permissions": {
+      "usageType": "openSource",
+      "licenses": [
+        {
+          "name": "Public Domain, CC0-1.0",
+          "URL": "LICENSE.md"
+        }
+      ]
+    },
+    "homepageURL": "",
+    "downloadURL": "",
+    "disclaimerURL": "",
+    "repositoryURL": "",
+    "vcs": "git",
+    "laborHours": 1,
+    "tags": [
+      "R",
+      "USGS"
+    ],
+    "languages": [
+      "R"
+    ],
+    "contact": {
+      "name": "",
+      "email": ""
+    },
+    "date": {
+      "metadataLastUpdated": "2022-10-16"
+    }
+  }
+]


### PR DESCRIPTION
Starting on September 30, 2023, USGS GitHub repositories will no longer be permitted to remain in existing organizations such as USGS-R on the public GitHub. Instead, they must be either (a) migrated to the [DOI GitHub Enterprise Cloud (DGEC)](https://github.com/DOI-USGS/), (b) migrated to the [USGS GitLab instance](https://code.usgs.gov/), or (c) archived.

In order to be made public, all USGS software, whether [provisional or approved](https://www.usgs.gov/products/software/software-management/types-software-review), must contain all necessary legal and metadata assets. The purpose of this PR is to ease the transition by creating the necessary files, so that people can do the necessary migration work with less research time.

The files added here are generated based on some assumptions, and without looking at the contents of any existing files. For instance, if this repo already has a `LICENSE.md`, the process which is generating this PR will not add one to the PR, but it does not make any attempt to validate the existing file. Similarly, the code is not at all clever about finding similarly-named files. For instance, if you already have a `LICENSE.txt`, this PR will try to create a `LICENSE.md` anyways!

The `DISCLAIMER.md` provided here is for a provisional release. If an official release is intended, a different disclaimer template may be found [here](https://code.chs.usgs.gov/software/software-management/-/tree/main/administrative_templates)

The `LICENSE.md` provided here is the most common choice, but as the owner of the repository you need to look it over and make sure that it is a good match for your repository. The [Office of the Solicitor](https://www.doi.gov/solicitor) is the only entity that can provide legal advice on this matter.

 Note especially that the `code.json` created by this PR will need to be manually edited in order to be correct. In this file, the following are likely to require modification:
* the "version" element simply chooses the repository's default branch, e.g. `main`. If there are tagged versions, they will need to be added by hand.
* the "status" element is listed as "Development". A correct value should be chosen from these possibilities: "Ideation", "Development", "Alpha", "Beta", "Release Candidate", "Production", or "Archival"
* the "hours" element is listed as 0. If an actual estimate of hours can be put in here, it should.
* the "tags" element only has "USGS". Other tags may be desirable to be added.
* the contact name is filled in with the GitHub username of the user with the most commits to the repo. It should be replaced with an actual name.
* the contact email must be filled in manually.

* the "metadata_last_updated" element should be filled with the date when you make the above changes.
For examples of valid `code.json` files, please see [https://github.com/DOI-USGS/dataRetrieval/blob/main/code.json](https://github.com/DOI-USGS/dataRetrieval/blob/main/code.json) or [https://github.com/DOI-USGS/snow-to-flow/blob/main/code.json](https://github.com/DOI-USGS/snow-to-flow/blob/main/code.json)In addition to the necessary legal and metadata assets, all public software requires a security review. See [this guidance](https://www.usgs.gov/products/software/software-management/types-software-review) for more information. Additionally, a useful FAQ with links to details of USGS policy and the specifics of this migration is located [here](https://doimspp.sharepoint.com/sites/Software/SitePages/Frequently-Asked-Questions.aspx?xsdata=MDV8MDF8fDljYTRhZTEwNzE3MjRmYmU5YjYzMDhkYWQ5ODhkMjg3fDA2OTNiNWJhNGIxODRkN2I5MzQxZjMyZjQwMGE1NDk0fDB8MHw2MzgwNjE0Nzg4OTcyMjg2NDN8VW5rbm93bnxWR1ZoYlhOVFpXTjFjbWwwZVZObGNuWnBZMlY4ZXlKV0lqb2lNQzR3TGpBd01EQWlMQ0pRSWpvaVYybHVNeklpTENKQlRpSTZJazkwYUdWeUlpd2lWMVFpT2pFeGZRPT18MXxNVFkzTURVMU1UQTRPRGc1TnpzeE5qY3dOVFV4TURnNE9EazNPekU1T2tOSmFsVkRNV1pCUzJWeVQwVmlablk1ZWt0alVqZzBPV1YwVGt4amFEWTNPVkYzWldkbGEyTXRaMUV4UUhSb2NtVmhaQzUwWVdOMk1nPT18N2RjMTIzMWQwZDAyNDUwNzliNjMwOGRhZDk4OGQyODd8ZWYwNmJkMDY5NjNkNDk5ZGJlNWQxNWNlNWQyOGE0MmE%3D&sdata=V0ZXMG5qQUVnTUdORUpnQ2FibHVBNWtaeVdxVkE5Nk13a1dPUEcrY1RnTT0%3D).